### PR TITLE
Add selective broadcast: per-pane include/exclude

### DIFF
--- a/webmux/frontend/src/components/Tile.tsx
+++ b/webmux/frontend/src/components/Tile.tsx
@@ -16,7 +16,8 @@ interface TileProps {
 export function Tile({ session, fontSize, onClose, onReconnect, onTitleMouseDown, isDragging, isDropTarget }: TileProps) {
   const [state, setState] = useState<ConnectionState>(session.state);
   const [viewerCount, setViewerCount] = useState(1);
-  const { focusedSessionId, broadcastMode } = useInputBroadcast();
+  const { focusedSessionId, broadcastMode, broadcastExcluded, toggleBroadcastExclude } = useInputBroadcast();
+  const isExcluded = broadcastExcluded.has(session.id);
   const termHandleRef = useRef<TerminalHandle>(null);
 
   const isFocused = focusedSessionId === session.id;
@@ -49,7 +50,7 @@ export function Tile({ session, fontSize, onClose, onReconnect, onTitleMouseDown
   const borderColor = isDropTarget
     ? '#7c6af7'
     : broadcastMode
-      ? '#e8a030'
+      ? (isExcluded ? '#333366' : '#e8a030')
       : isFocused
         ? '#7c6af7'
         : '#333366';
@@ -63,7 +64,7 @@ export function Tile({ session, fontSize, onClose, onReconnect, onTitleMouseDown
         boxShadow: isDropTarget
           ? '0 0 12px rgba(124, 106, 247, 0.6)'
           : broadcastMode
-            ? '0 0 8px rgba(232, 160, 48, 0.4)'
+            ? (isExcluded ? 'none' : '0 0 8px rgba(232, 160, 48, 0.4)')
             : isFocused
               ? '0 0 8px rgba(124, 106, 247, 0.4)'
               : 'none',
@@ -82,6 +83,17 @@ export function Tile({ session, fontSize, onClose, onReconnect, onTitleMouseDown
           <span style={styles.transport}>{session.transport.toUpperCase()}</span>
         </div>
         <div style={styles.chromeRight}>
+          {broadcastMode && (
+            <button
+              style={{
+                ...styles.chromeBtn,
+                color: isExcluded ? '#666' : '#e8a030',
+                fontSize: 10,
+              }}
+              onClick={() => toggleBroadcastExclude(session.id)}
+              title={isExcluded ? 'Excluded from broadcast (click to include)' : 'Included in broadcast (click to exclude)'}
+            >{isExcluded ? '\u25cb' : '\u25cf'}</button>
+          )}
           {viewerCount > 1 && (
             <span style={styles.viewers} title={`${viewerCount} viewers`}>
               {viewerCount}

--- a/webmux/frontend/src/contexts/InputBroadcastContext.tsx
+++ b/webmux/frontend/src/contexts/InputBroadcastContext.tsx
@@ -12,6 +12,9 @@ interface InputBroadcastState {
   unregisterSend: (sessionId: string) => void;
   /** Route input: if broadcast mode, send to all; otherwise send to focused only. */
   routeInput: (fromSessionId: string, data: string) => void;
+  /** Sessions excluded from broadcast */
+  broadcastExcluded: Set<string>;
+  toggleBroadcastExclude: (sessionId: string) => void;
 }
 
 const InputBroadcastContext = createContext<InputBroadcastState | null>(null);
@@ -19,10 +22,13 @@ const InputBroadcastContext = createContext<InputBroadcastState | null>(null);
 export function InputBroadcastProvider({ children }: { children: ReactNode }) {
   const [broadcastMode, setBroadcastMode] = useState(false);
   const [focusedSessionId, setFocusedSessionIdState] = useState<string | null>(null);
+  const [broadcastExcluded, setBroadcastExcluded] = useState<Set<string>>(new Set());
   const sendFns = useRef(new Map<string, SendFn>());
   const broadcastModeRef = useRef(broadcastMode);
+  const broadcastExcludedRef = useRef(broadcastExcluded);
 
   useEffect(() => { broadcastModeRef.current = broadcastMode; }, [broadcastMode]);
+  useEffect(() => { broadcastExcludedRef.current = broadcastExcluded; }, [broadcastExcluded]);
 
   const registerSend = useCallback((sessionId: string, send: SendFn) => {
     sendFns.current.set(sessionId, send);
@@ -36,9 +42,24 @@ export function InputBroadcastProvider({ children }: { children: ReactNode }) {
     setFocusedSessionIdState(id);
   }, []);
 
+  const toggleBroadcastExclude = useCallback((sessionId: string) => {
+    setBroadcastExcluded(prev => {
+      const next = new Set(prev);
+      if (next.has(sessionId)) {
+        next.delete(sessionId);
+      } else {
+        next.add(sessionId);
+      }
+      return next;
+    });
+  }, []);
+
   const routeInput = useCallback((fromSessionId: string, data: string) => {
     if (broadcastModeRef.current) {
-      sendFns.current.forEach(send => send(data));
+      const excluded = broadcastExcludedRef.current;
+      sendFns.current.forEach((send, id) => {
+        if (!excluded.has(id)) send(data);
+      });
     } else {
       const send = sendFns.current.get(fromSessionId);
       if (send) send(data);
@@ -53,7 +74,9 @@ export function InputBroadcastProvider({ children }: { children: ReactNode }) {
     registerSend,
     unregisterSend,
     routeInput,
-  }), [broadcastMode, focusedSessionId, setFocusedSessionId, registerSend, unregisterSend, routeInput]);
+    broadcastExcluded,
+    toggleBroadcastExclude,
+  }), [broadcastMode, focusedSessionId, setFocusedSessionId, registerSend, unregisterSend, routeInput, broadcastExcluded, toggleBroadcastExclude]);
 
   return (
     <InputBroadcastContext.Provider value={value}>


### PR DESCRIPTION
## Summary

- When "Type to All" broadcast mode is active, each tile now shows a toggle button in its chrome bar
- Click to exclude a pane from receiving broadcast input (empty circle, gray) or re-include it (filled circle, orange)
- Excluded panes lose the orange border/glow for clear visual feedback
- Exclusion state is managed in `InputBroadcastContext` and checked in `routeInput` before forwarding keystrokes

## Test plan

- [ ] Enable "Type to All" — verify all panes show the broadcast toggle (filled orange circle)
- [ ] Click the toggle on one pane — verify it switches to empty gray circle and the border reverts to default
- [ ] Type in any pane — verify excluded pane does NOT receive the input while included panes do
- [ ] Click the toggle again — verify the pane is re-included and receives broadcast input
- [ ] Disable "Type to All" — verify toggles disappear and input routes normally