### PR TITLE
Enable Option-as-Meta on macOS terminals

### DIFF
--- a/webmux/frontend/src/components/Terminal.tsx
+++ b/webmux/frontend/src/components/Terminal.tsx
@@ -123,6 +123,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       fontFamily: 'Consolas, Menlo, "DejaVu Sans Mono", monospace',
       fontSize,
       cursorBlink: true,
+      macOptionIsMeta: /Mac|iPhone|iPad/.test(navigator.platform),
       allowTransparency: false,
       scrollback: 5000,
       linkHandler: {


### PR DESCRIPTION
## Summary

- Auto-detect Apple platforms and enable xterm.js `macOptionIsMeta` so Option+f/b/d/backspace send proper escape sequences instead of compose characters (ƒ∂∑)
- No effect on Linux/Windows clients

## Test plan

- [ ] On macOS: Option+f moves forward one word, Option+b moves back, Option+d deletes word forward, Option+backspace deletes word back
- [ ] On Linux/Windows: no change in behavior