### PR TITLE
Add drag-and-drop file upload to terminal tiles

### DIFF
--- a/webmux/backend/src/api/upload.ts
+++ b/webmux/backend/src/api/upload.ts
@@ -1,0 +1,57 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../middleware/auth';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+
+const router = Router();
+router.use(requireAuth);
+
+const UPLOAD_DIR = path.join(process.env.WEBMUX_HOME || path.join(process.env.HOME || '/tmp', '.config/webmux'), 'uploads');
+const MAX_SIZE = 10 * 1024 * 1024; // 10 MB
+
+// Allowed filename characters (prevent path traversal)
+const SAFE_NAME_RE = /^[a-zA-Z0-9._-]+$/;
+
+router.post('/', (req: Request, res: Response) => {
+  const contentType = req.headers['content-type'] || '';
+  if (!contentType.startsWith('application/octet-stream')) {
+    res.status(400).json({ error: 'Content-Type must be application/octet-stream' });
+    return;
+  }
+
+  const rawName = req.headers['x-filename'] as string | undefined;
+  const ext = rawName ? path.extname(rawName) : '';
+  const prefix = crypto.randomBytes(6).toString('hex');
+  const safeName = rawName && SAFE_NAME_RE.test(path.basename(rawName))
+    ? `${prefix}-${path.basename(rawName)}`
+    : `${prefix}${ext || '.bin'}`;
+
+  fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+
+  const filePath = path.join(UPLOAD_DIR, safeName);
+  const chunks: Buffer[] = [];
+  let size = 0;
+
+  req.on('data', (chunk: Buffer) => {
+    size += chunk.length;
+    if (size > MAX_SIZE) {
+      res.status(413).json({ error: 'File too large (max 10 MB)' });
+      req.destroy();
+      return;
+    }
+    chunks.push(chunk);
+  });
+
+  req.on('end', () => {
+    if (res.writableEnded) return;
+    fs.writeFileSync(filePath, Buffer.concat(chunks));
+    res.status(201).json({ path: filePath, name: safeName, size });
+  });
+
+  req.on('error', () => {
+    res.status(500).json({ error: 'Upload failed' });
+  });
+});
+
+export default router;

--- a/webmux/backend/src/index.ts
+++ b/webmux/backend/src/index.ts
@@ -12,6 +12,7 @@ import hostsRouter from './api/hosts';
 import keysRouter from './api/keys';
 import sessionsRouter from './api/sessions';
 import configRouter from './api/config';
+import uploadRouter from './api/upload';
 import { setupWebSocket } from './websocket/handler';
 import { sessionBroker } from './services/sessionBroker';
 import { persistence, LOGS_DIR } from './services/persistenceManager';
@@ -67,6 +68,7 @@ async function main(): Promise<void> {
   app.use('/api/keys', keysRouter);
   app.use('/api/sessions', sessionsRouter);
   app.use('/api/config', configRouter);
+  app.use('/api/upload', uploadRouter);
 
   // Health check
   app.get('/api/health', (_req, res) => {

--- a/webmux/frontend/src/components/Terminal.tsx
+++ b/webmux/frontend/src/components/Terminal.tsx
@@ -9,6 +9,7 @@ import { useInputBroadcast } from '../contexts/InputBroadcastContext';
 
 export interface TerminalHandle {
   scrollToBottom: () => void;
+  sendInput: (data: string) => void;
 }
 
 interface TerminalProps {
@@ -37,6 +38,9 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
 
   useImperativeHandle(ref, () => ({
     scrollToBottom: () => { termRef.current?.scrollToBottom(); },
+    sendInput: (data: string) => {
+      wsHandleRef.current?.send({ type: 'input', data });
+    },
   }));
 
   // Keep latest callbacks in refs so xterm/WS handlers never capture stale closures.

--- a/webmux/frontend/src/components/Tile.tsx
+++ b/webmux/frontend/src/components/Tile.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef } from 'react';
 import { Terminal, type TerminalHandle } from './Terminal';
 import { useInputBroadcast } from '../contexts/InputBroadcastContext';
+import { api } from '../utils/api';
 import type { Session, ConnectionState } from '../types';
 
 interface TileProps {
@@ -38,6 +39,22 @@ export function Tile({ session, fontSize, onClose, onReconnect, onTitleMouseDown
     onTitleMouseDown?.(session.id, e);
   }, [onTitleMouseDown, session.id]);
 
+  const [fileDragOver, setFileDragOver] = useState(false);
+
+  const handleFileDrop = useCallback(async (e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setFileDragOver(false);
+    const files = e.dataTransfer.files;
+    if (files.length === 0) return;
+    try {
+      const result = await api.uploadFile(files[0]);
+      termHandleRef.current?.sendInput(result.path + ' ');
+    } catch (err) {
+      console.error('File upload failed:', err);
+    }
+  }, []);
+
   const stateColor = state === 'connected' ? '#4aaa6a' :
     state === 'connecting' ? '#caaa4a' :
     state === 'error' ? '#ff5555' : '#888888';
@@ -57,10 +74,15 @@ export function Tile({ session, fontSize, onClose, onReconnect, onTitleMouseDown
   return (
     <div
       onWheel={e => { if (!e.shiftKey) e.stopPropagation(); }}
+      onDragOver={e => { e.preventDefault(); e.stopPropagation(); setFileDragOver(true); }}
+      onDragLeave={e => { e.preventDefault(); e.stopPropagation(); setFileDragOver(false); }}
+      onDrop={handleFileDrop}
       style={{
         ...styles.tile,
-        borderColor,
-        boxShadow: isDropTarget
+        borderColor: fileDragOver ? '#50fa7b' : borderColor,
+        boxShadow: fileDragOver
+          ? '0 0 12px rgba(80, 250, 123, 0.6)'
+          : isDropTarget
           ? '0 0 12px rgba(124, 106, 247, 0.6)'
           : broadcastMode
             ? '0 0 8px rgba(232, 160, 48, 0.4)'

--- a/webmux/frontend/src/utils/api.ts
+++ b/webmux/frontend/src/utils/api.ts
@@ -64,6 +64,26 @@ export const api = {
       method: 'PATCH',
       body: JSON.stringify({ row, col }),
     }),
+  // Upload
+  uploadFile: async (file: File): Promise<{ path: string; name: string; size: number }> => {
+    const token = getToken();
+    const headers: HeadersInit = {
+      'Content-Type': 'application/octet-stream',
+      'X-Filename': file.name,
+    };
+    if (token) headers['Authorization'] = `Bearer ${token}`;
+    const res = await fetch(`${API_BASE}/upload`, {
+      method: 'POST',
+      headers,
+      body: file,
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({ error: res.statusText }));
+      throw new Error((err as { error?: string }).error || res.statusText);
+    }
+    return res.json();
+  },
+
   // Hosts
   getHosts: () => request<HostEntry[]>('/hosts'),
   createHost: (host: Partial<HostEntry>) =>


### PR DESCRIPTION
## Summary

- Drag a file (image, text, anything) onto a terminal tile to upload it to the webmux server
- File is saved to `~/.config/webmux/uploads/` with a randomized prefix
- The server-side file path is pasted into the terminal as input text
- Green border glow on the tile during drag-over for visual feedback
- 10 MB size limit, filename sanitization to prevent path traversal

## Changes

- New `POST /api/upload` endpoint (octet-stream body, `X-Filename` header)
- `api.uploadFile()` client method
- `TerminalHandle.sendInput()` for programmatic input injection
- Drop event handling on Tile component

## Test plan

- [ ] Drag an image onto a terminal tile — verify green glow appears
- [ ] Drop the file — verify path like `~/.config/webmux/uploads/abc123-image.png` is typed into the terminal
- [ ] Verify the file exists at that path on the server
- [ ] Drop a file > 10 MB — verify 413 error
- [ ] Drop a file with special characters in the name — verify sanitized filename