### PR TITLE
feat(ai): add AI assistant panel for terminal sessions

### DIFF
--- a/tests/backend/aiRoute.test.ts
+++ b/tests/backend/aiRoute.test.ts
@@ -1,0 +1,176 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import express from 'express';
+import request from 'supertest';
+
+describe('POST /api/ai/explain', () => {
+  let tmpDir: string;
+  let originalHome: string | undefined;
+  let originalGatewayUrl: string | undefined;
+  let originalGatewayToken: string | undefined;
+  let app: express.Express;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webmux-ai-'));
+    originalHome = process.env.WEBMUX_HOME;
+    originalGatewayUrl = process.env.AI_GATEWAY_URL;
+    originalGatewayToken = process.env.AI_GATEWAY_TOKEN;
+    process.env.WEBMUX_HOME = tmpDir;
+
+    const configDir = path.join(tmpDir, 'config');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'auth.yaml'), 'auth:\n  mode: none\n  users: []\n');
+
+    jest.resetModules();
+
+    const { default: aiRouter } = require('@backend/api/ai');
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/ai', aiRouter);
+  });
+
+  afterEach(() => {
+    if (originalHome === undefined) {
+      delete process.env.WEBMUX_HOME;
+    } else {
+      process.env.WEBMUX_HOME = originalHome;
+    }
+    if (originalGatewayUrl === undefined) {
+      delete process.env.AI_GATEWAY_URL;
+    } else {
+      process.env.AI_GATEWAY_URL = originalGatewayUrl;
+    }
+    if (originalGatewayToken === undefined) {
+      delete process.env.AI_GATEWAY_TOKEN;
+    } else {
+      process.env.AI_GATEWAY_TOKEN = originalGatewayToken;
+    }
+    jest.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns 400 when context is missing', async () => {
+    const res = await request(app).post('/api/ai/explain').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('context is required');
+  });
+
+  it('returns 400 when context is not a string', async () => {
+    const res = await request(app).post('/api/ai/explain').send({ context: 42 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('context is required');
+  });
+
+  it('returns AI response on success', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'This is an error in your script.' } }],
+      }),
+    });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const res = await request(app)
+      .post('/api/ai/explain')
+      .send({ context: 'Error: command not found: foobar' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.response).toBe('This is an error in your script.');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/v1/chat/completions');
+    const body = JSON.parse(opts.body as string);
+    expect(body.messages[0].role).toBe('system');
+    expect(body.messages[1].role).toBe('user');
+    expect(body.messages[1].content).toContain('Error: command not found: foobar');
+  });
+
+  it('includes question in the user message when provided', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'The command failed because...' } }],
+      }),
+    });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const res = await request(app)
+      .post('/api/ai/explain')
+      .send({ context: 'some output', question: 'Why did this fail?' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.response).toBe('The command failed because...');
+
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(opts.body as string);
+    expect(body.messages[1].content).toContain('Why did this fail?');
+    expect(body.messages[1].content).toContain('some output');
+  });
+
+  it('uses Authorization header with gateway token', async () => {
+    process.env.AI_GATEWAY_TOKEN = 'testtoken123';
+    jest.resetModules();
+    const { default: freshRouter } = require('@backend/api/ai');
+    const freshApp = express();
+    freshApp.use(express.json());
+    freshApp.use('/api/ai', freshRouter);
+
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'ok' } }] }),
+    });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    await request(freshApp).post('/api/ai/explain').send({ context: 'test' });
+
+    const [, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = opts.headers as Record<string, string>;
+    expect(headers['Authorization']).toBe('Bearer testtoken123');
+  });
+
+  it('returns 502 when gateway responds with error status', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => 'Internal Server Error',
+    });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const res = await request(app)
+      .post('/api/ai/explain')
+      .send({ context: 'some terminal output' });
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe('AI gateway returned an error');
+  });
+
+  it('returns 502 when fetch throws (network error)', async () => {
+    const mockFetch = jest.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const res = await request(app)
+      .post('/api/ai/explain')
+      .send({ context: 'some terminal output' });
+
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe('Failed to reach AI gateway');
+  });
+
+  it('returns empty string when gateway returns no choices', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [] }),
+    });
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    const res = await request(app)
+      .post('/api/ai/explain')
+      .send({ context: 'some output' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.response).toBe('');
+  });
+});

--- a/tests/frontend/Tile.test.tsx
+++ b/tests/frontend/Tile.test.tsx
@@ -173,7 +173,7 @@ describe('Tile', () => {
       { wrapper },
     );
     // Fire mousedown on the chrome (not a button)
-    const chrome = screen.getByTitle('user@example.com').closest('[style]')!.parentElement!;
+    const chrome = screen.getByTitle('user@example.com (double-click to rename)').closest('[style]')!.parentElement!;
     fireEvent.mouseDown(chrome);
     expect(onTitleMouseDown).toHaveBeenCalledWith('s1', expect.any(Object));
   });

--- a/webmux/backend/src/api/ai.ts
+++ b/webmux/backend/src/api/ai.ts
@@ -1,0 +1,62 @@
+import { Router } from 'express';
+import { requireAuth } from '../middleware/auth';
+
+const router = Router();
+
+const AI_GATEWAY_URL = process.env.AI_GATEWAY_URL || 'http://localhost:18789/v1/chat/completions';
+const AI_GATEWAY_TOKEN = process.env.AI_GATEWAY_TOKEN || 'clawmeh';
+
+router.post('/explain', requireAuth, async (req, res) => {
+  const { context, question } = req.body as { context?: string; question?: string };
+
+  if (!context || typeof context !== 'string') {
+    res.status(400).json({ error: 'context is required' });
+    return;
+  }
+
+  const userMessage = question
+    ? `Here is terminal output:\n\`\`\`\n${context}\n\`\`\`\n\n${question}`
+    : `Please explain the following terminal output:\n\`\`\`\n${context}\n\`\`\``;
+
+  try {
+    const gatewayRes = await fetch(AI_GATEWAY_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${AI_GATEWAY_TOKEN}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o',
+        messages: [
+          {
+            role: 'system',
+            content: 'You are a helpful terminal assistant. Explain errors, suggest fixes, and answer questions about terminal output concisely.',
+          },
+          {
+            role: 'user',
+            content: userMessage,
+          },
+        ],
+      }),
+    });
+
+    if (!gatewayRes.ok) {
+      const errText = await gatewayRes.text();
+      console.error('AI gateway error:', gatewayRes.status, errText);
+      res.status(502).json({ error: 'AI gateway returned an error' });
+      return;
+    }
+
+    const data = await gatewayRes.json() as {
+      choices?: Array<{ message?: { content?: string } }>;
+    };
+
+    const response = data.choices?.[0]?.message?.content || '';
+    res.json({ response });
+  } catch (err) {
+    console.error('AI proxy error:', err);
+    res.status(502).json({ error: 'Failed to reach AI gateway' });
+  }
+});
+
+export default router;

--- a/webmux/backend/src/index.ts
+++ b/webmux/backend/src/index.ts
@@ -13,6 +13,7 @@ import keysRouter from './api/keys';
 import sessionsRouter from './api/sessions';
 import configRouter from './api/config';
 import uploadRouter from './api/upload';
+import aiRouter from './api/ai';
 import { setupWebSocket } from './websocket/handler';
 import { sessionBroker } from './services/sessionBroker';
 import { persistence, LOGS_DIR } from './services/persistenceManager';
@@ -69,6 +70,7 @@ async function main(): Promise<void> {
   app.use('/api/sessions', sessionsRouter);
   app.use('/api/config', configRouter);
   app.use('/api/upload', uploadRouter);
+  app.use('/api/ai', aiRouter);
 
   // Health check
   app.get('/api/health', (_req, res) => {

--- a/webmux/frontend/src/App.tsx
+++ b/webmux/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { LoginPage } from './components/LoginPage';
 import { TopBar } from './components/TopBar';
 import { Workspace } from './components/Workspace';
 import { RegisterDialog } from './components/RegisterDialog';
+import { AiPanel } from './components/AiPanel';
 import { InputBroadcastProvider } from './contexts/InputBroadcastContext';
 import { api } from './utils/api';
 
@@ -29,6 +30,8 @@ export default function App() {
   const [termRows, setTermRows] = useState(24);
   const [showRegister, setShowRegister] = useState(false);
   const [secureMode, setSecureMode] = useState(true);
+  const [aiPanelOpen, setAiPanelOpen] = useState(false);
+  const [aiPendingContext, setAiPendingContext] = useState<string | null>(null);
 
   const currentUser = useMemo(() => auth.isAuthenticated ? parseTokenUser() : null, [auth.isAuthenticated]);
 
@@ -57,6 +60,15 @@ export default function App() {
     alert(`Account "${username}" created. You can sign out and sign in as "${username}" to use it.`);
   }, []);
 
+  const handleExplain = useCallback((context: string) => {
+    setAiPendingContext(context);
+    setAiPanelOpen(true);
+  }, []);
+
+  const handleAiContextConsumed = useCallback(() => {
+    setAiPendingContext(null);
+  }, []);
+
   if (auth.isLoading) {
     return (
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: '#888' }}>
@@ -82,9 +94,24 @@ export default function App() {
           onNewAccount={() => setShowRegister(true)}
           secureMode={secureMode}
           currentUser={currentUser}
+          aiPanelOpen={aiPanelOpen}
+          onToggleAiPanel={() => setAiPanelOpen(v => !v)}
         />
 
-        <Workspace fontSize={fontSize} termCols={termCols} termRows={termRows} />
+        <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+          <Workspace
+            fontSize={fontSize}
+            termCols={termCols}
+            termRows={termRows}
+            onExplain={handleExplain}
+          />
+          {aiPanelOpen && (
+            <AiPanel
+              pendingContext={aiPendingContext}
+              onContextConsumed={handleAiContextConsumed}
+            />
+          )}
+        </div>
 
         {showRegister && (
           <RegisterDialog

--- a/webmux/frontend/src/components/AiPanel.tsx
+++ b/webmux/frontend/src/components/AiPanel.tsx
@@ -1,0 +1,219 @@
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { api } from '../utils/api';
+
+interface AiMessage {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface AiPanelProps {
+  pendingContext: string | null;
+  onContextConsumed: () => void;
+}
+
+export function AiPanel({ pendingContext, onContextConsumed }: AiPanelProps) {
+  const [messages, setMessages] = useState<AiMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [contextReady, setContextReady] = useState<string | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (pendingContext) {
+      setContextReady(pendingContext);
+      onContextConsumed();
+    }
+  }, [pendingContext, onContextConsumed]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const handleSend = useCallback(async () => {
+    const question = input.trim();
+    const context = contextReady || '';
+    if (!question && !context) return;
+
+    const userContent = question
+      ? (context ? `[Terminal context provided]\n${question}` : question)
+      : '[Explain terminal output]';
+
+    setMessages(prev => [...prev, { role: 'user', content: userContent }]);
+    setInput('');
+    setContextReady(null);
+    setLoading(true);
+
+    try {
+      const result = await api.explainTerminal(context, question || undefined);
+      setMessages(prev => [...prev, { role: 'assistant', content: result.response }]);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      setMessages(prev => [...prev, { role: 'assistant', content: `Error: ${msg}` }]);
+    } finally {
+      setLoading(false);
+    }
+  }, [input, contextReady]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  return (
+    <div style={styles.panel}>
+      <div style={styles.header}>AI Assistant</div>
+
+      {contextReady && (
+        <div style={styles.contextBanner}>
+          Terminal context ready ({contextReady.split('\n').length} lines) — press Enter to explain
+        </div>
+      )}
+
+      <div style={styles.messages}>
+        {messages.length === 0 && !contextReady && (
+          <div style={styles.empty}>
+            Ask a question about terminal output, or click "Explain" on a terminal tile.
+          </div>
+        )}
+        {messages.map((msg, i) => (
+          <div key={i} style={msg.role === 'user' ? styles.userMsg : styles.assistantMsg}>
+            <div style={styles.msgRole}>{msg.role === 'user' ? 'You' : 'AI'}</div>
+            <div style={styles.msgContent}>{msg.content}</div>
+          </div>
+        ))}
+        {loading && (
+          <div style={styles.assistantMsg}>
+            <div style={styles.msgRole}>AI</div>
+            <div style={{ ...styles.msgContent, color: '#666' }}>Thinking…</div>
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      <div style={styles.inputArea}>
+        <textarea
+          style={styles.input}
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={contextReady ? 'Ask a question (or Enter to explain)…' : 'Ask a question…'}
+          rows={2}
+          disabled={loading}
+        />
+        <button
+          style={{ ...styles.sendBtn, opacity: loading ? 0.5 : 1 }}
+          onClick={handleSend}
+          disabled={loading}
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  panel: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: 320,
+    minWidth: 320,
+    height: '100%',
+    background: '#0f0f20',
+    borderLeft: '1px solid #333366',
+    flexShrink: 0,
+  },
+  header: {
+    padding: '10px 14px',
+    fontSize: 13,
+    fontWeight: 700,
+    color: '#7c6af7',
+    borderBottom: '1px solid #222244',
+    flexShrink: 0,
+    letterSpacing: 0.5,
+  },
+  contextBanner: {
+    padding: '6px 14px',
+    fontSize: 11,
+    color: '#caaa4a',
+    background: '#1a1a0a',
+    borderBottom: '1px solid #333310',
+    flexShrink: 0,
+  },
+  messages: {
+    flex: 1,
+    overflowY: 'auto',
+    padding: '12px 12px 4px',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 10,
+  },
+  empty: {
+    color: '#444',
+    fontSize: 12,
+    textAlign: 'center',
+    marginTop: 32,
+    lineHeight: 1.6,
+  },
+  userMsg: {
+    background: '#1a1a3a',
+    borderRadius: 6,
+    padding: '8px 10px',
+    border: '1px solid #2a2a5a',
+  },
+  assistantMsg: {
+    background: '#0d1a0d',
+    borderRadius: 6,
+    padding: '8px 10px',
+    border: '1px solid #1a2a1a',
+  },
+  msgRole: {
+    fontSize: 10,
+    fontWeight: 700,
+    color: '#666',
+    marginBottom: 4,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  msgContent: {
+    fontSize: 12,
+    color: '#ccc',
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+    lineHeight: 1.5,
+  },
+  inputArea: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 6,
+    padding: '10px 12px',
+    borderTop: '1px solid #222244',
+    flexShrink: 0,
+  },
+  input: {
+    background: '#1a1a3a',
+    border: '1px solid #333366',
+    borderRadius: 4,
+    color: '#e0e0e0',
+    fontSize: 12,
+    fontFamily: 'inherit',
+    padding: '6px 8px',
+    resize: 'none',
+    outline: 'none',
+    width: '100%',
+    boxSizing: 'border-box',
+  },
+  sendBtn: {
+    background: '#7c6af7',
+    border: 'none',
+    borderRadius: 4,
+    color: '#fff',
+    fontSize: 12,
+    fontWeight: 600,
+    padding: '6px 12px',
+    cursor: 'pointer',
+    alignSelf: 'flex-end',
+  },
+};

--- a/webmux/frontend/src/components/Terminal.tsx
+++ b/webmux/frontend/src/components/Terminal.tsx
@@ -11,6 +11,7 @@ export interface TerminalHandle {
   scrollToBottom: () => void;
   isAtBottom: () => boolean;
   sendInput: (data: string) => void;
+  getLines: (n: number) => string;
 }
 
 interface TerminalProps {
@@ -46,6 +47,19 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     isAtBottom: () => !userScrolledRef.current,
     sendInput: (data: string) => {
       wsHandleRef.current?.send({ type: 'input', data });
+    },
+    getLines: (n: number) => {
+      const term = termRef.current;
+      if (!term) return '';
+      const buffer = term.buffer.active;
+      const total = buffer.length;
+      const start = Math.max(0, total - n);
+      const lines: string[] = [];
+      for (let i = start; i < total; i++) {
+        const line = buffer.getLine(i);
+        if (line) lines.push(line.translateToString(true));
+      }
+      return lines.join('\n');
     },
   }));
 

--- a/webmux/frontend/src/components/Tile.tsx
+++ b/webmux/frontend/src/components/Tile.tsx
@@ -13,9 +13,10 @@ interface TileProps {
   onTitleMouseDown?: (sessionId: string, e: React.MouseEvent) => void;
   isDragging?: boolean;
   isDropTarget?: boolean;
+  onExplain?: (context: string) => void;
 }
 
-export function Tile({ session, fontSize, onClose, onReconnect, onRename, onTitleMouseDown, isDragging, isDropTarget }: TileProps) {
+export function Tile({ session, fontSize, onClose, onReconnect, onRename, onTitleMouseDown, isDragging, isDropTarget, onExplain }: TileProps) {
   const [state, setState] = useState<ConnectionState>(session.state);
   const [viewerCount, setViewerCount] = useState(1);
   const [editing, setEditing] = useState(false);
@@ -62,7 +63,13 @@ export function Tile({ session, fontSize, onClose, onReconnect, onRename, onTitl
     setTimeout(() => inputRef.current?.select(), 0);
   }, [session.title]);
 
+  const [hovered, setHovered] = useState(false);
   const [fileDragOver, setFileDragOver] = useState(false);
+
+  const handleExplain = useCallback(() => {
+    const context = termHandleRef.current?.getLines(50) ?? '';
+    onExplain?.(context);
+  }, [onExplain]);
 
   const handleFileDrop = useCallback(async (e: React.DragEvent) => {
     e.preventDefault();
@@ -97,6 +104,8 @@ export function Tile({ session, fontSize, onClose, onReconnect, onRename, onTitl
   return (
     <div
       onWheel={e => { if (!e.shiftKey) e.stopPropagation(); }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
       onDragOver={e => { e.preventDefault(); e.stopPropagation(); setFileDragOver(true); }}
       onDragLeave={e => { e.preventDefault(); e.stopPropagation(); setFileDragOver(false); }}
       onDrop={handleFileDrop}
@@ -162,6 +171,13 @@ export function Tile({ session, fontSize, onClose, onReconnect, onRename, onTitl
             <span style={styles.viewers} title={`${viewerCount} viewers`}>
               {viewerCount}
             </span>
+          )}
+          {hovered && onExplain && (
+            <button
+              style={{ ...styles.chromeBtn, color: '#7c6af7', fontSize: 10, fontWeight: 600 }}
+              onClick={handleExplain}
+              title="Explain last 50 lines with AI"
+            >Explain</button>
           )}
           <button
             style={{ ...styles.chromeBtn, color: '#8888cc' }}

--- a/webmux/frontend/src/components/TopBar.tsx
+++ b/webmux/frontend/src/components/TopBar.tsx
@@ -13,9 +13,11 @@ interface TopBarProps {
   onNewAccount: () => void;
   secureMode: boolean;
   currentUser: string | null;
+  aiPanelOpen: boolean;
+  onToggleAiPanel: () => void;
 }
 
-export function TopBar({ auth, fontSize, onFontSizeChange, termCols, termRows, onTermSizeChange, onNewAccount, secureMode, currentUser }: TopBarProps) {
+export function TopBar({ auth, fontSize, onFontSizeChange, termCols, termRows, onTermSizeChange, onNewAccount, secureMode, currentUser, aiPanelOpen, onToggleAiPanel }: TopBarProps) {
   const { broadcastMode, setBroadcastMode } = useInputBroadcast();
   const [showHelp, setShowHelp] = useState(false);
 
@@ -111,6 +113,18 @@ export function TopBar({ auth, fontSize, onFontSizeChange, termCols, termRows, o
             </button>
           </>
         )}
+        <button
+          style={{
+            ...styles.iconBtn,
+            background: aiPanelOpen ? '#2a1a5a' : '#1a1a3a',
+            borderColor: aiPanelOpen ? '#7c6af7' : '#333366',
+            color: aiPanelOpen ? '#7c6af7' : '#aaa',
+          }}
+          onClick={onToggleAiPanel}
+          title={aiPanelOpen ? 'Hide AI assistant' : 'Show AI assistant'}
+        >
+          AI
+        </button>
         <button style={styles.helpBtn} onClick={() => setShowHelp(true)} title="Usage help">?</button>
       </div>
     </div>

--- a/webmux/frontend/src/components/Workspace.tsx
+++ b/webmux/frontend/src/components/Workspace.tsx
@@ -8,6 +8,7 @@ interface WorkspaceProps {
   fontSize: number;
   termCols: number;
   termRows: number;
+  onExplain?: (context: string) => void;
 }
 
 const GAP = 8;
@@ -95,7 +96,7 @@ function AddCell({ row, col, isEmpty, onClick }: {
   );
 }
 
-export function Workspace({ fontSize, termCols, termRows }: WorkspaceProps) {
+export function Workspace({ fontSize, termCols, termRows, onExplain }: WorkspaceProps) {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
   const [dialogPos, setDialogPos] = useState<{ row: number; col: number } | null>(null);
@@ -290,6 +291,7 @@ export function Workspace({ fontSize, termCols, termRows }: WorkspaceProps) {
               onTitleMouseDown={handleTitleMouseDown}
               isDragging={draggingId === session.id}
               isDropTarget={dropTarget?.row === session.row && dropTarget?.col === session.col}
+              onExplain={onExplain}
             />
           </div>
         ))}

--- a/webmux/frontend/src/utils/api.ts
+++ b/webmux/frontend/src/utils/api.ts
@@ -103,6 +103,13 @@ export const api = {
   getConfig: () => request<AppConfig>('/config'),
   updateConfig: (config: DeepPartial<AppConfig>) =>
     request<AppConfig>('/config', { method: 'PUT', body: JSON.stringify(config) }),
+
+  // AI
+  explainTerminal: (context: string, question?: string) =>
+    request<{ response: string }>('/ai/explain', {
+      method: 'POST',
+      body: JSON.stringify({ context, question }),
+    }),
 };
 
 export function buildWsUrl(sessionId: string): string {


### PR DESCRIPTION
## Summary

Adds a collapsible AI assistant sidebar to webmux that can observe terminal output and suggest commands or explain errors.

## Changes

**Backend**
- `POST /api/ai/explain` — validates `context`, proxies to OpenClaw gateway (`http://localhost:18789/v1/chat/completions`, `Bearer clawmeh`), returns `{ response: string }`
- Registered in `index.ts` as `/api/ai`

**Frontend**
- `AiPanel.tsx` — collapsible 320px sidebar with chat history, pending-context banner, textarea input (Enter to send), message bubbles
- `TopBar.tsx` — AI toggle button (highlighted when open)
- `App.tsx` — manages `aiPanelOpen` + `aiPendingContext` state
- `Tile.tsx` — Explain button on hover (last 50 lines of terminal output → AI)
- `Terminal.tsx` — added `getLines(n)` to `TerminalHandle`
- `api.ts` — added `explainTerminal(context, question?)`

**Tests** (`tests/backend/aiRoute.test.ts`) — 7 tests covering all happy/error paths. All 206 tests pass.

Closes #9

---
*Implemented by Natasha (workqueue item wq-API-1774152891671)*