### PR TITLE
feat: Claude CLI session template with guided SSO auth flow

### DIFF
--- a/webmux/backend/src/services/sessionBroker.ts
+++ b/webmux/backend/src/services/sessionBroker.ts
@@ -6,6 +6,10 @@ import { transportLauncher } from './transportLauncher';
 import { presenceService } from './presenceService';
 import { persistence } from './persistenceManager';
 
+// Matches claude.ai / Anthropic OAuth URLs in PTY output
+const CLAUDE_AUTH_URL_RE = /https:\/\/(?:claude\.ai|auth\.anthropic\.com|console\.anthropic\.com)\/[^\s\x1b\x07\r\n]*/;
+const CLAUDE_AUTH_SUCCESS_RE = /authentication successful|logged in successfully|successfully authenticated/i;
+
 export class SessionBroker extends EventEmitter {
   private sessions = new Map<string, Session>();
   private scrollback = new Map<string, string>();
@@ -94,14 +98,16 @@ export class SessionBroker extends EventEmitter {
       }
     }
 
+    const isClaude = req.session_type === 'claude';
+
     const session: Session = {
       id,
       owner,
-      transport,
+      transport: isClaude ? 'claude' : transport,
       host_id: req.host_id || '',
-      hostname,
-      port,
-      username: req.username,
+      hostname: isClaude ? 'localhost' : hostname,
+      port: isClaude ? 0 : port,
+      username: req.username || '',
       key_id: req.key_id || '',
       cols: req.cols || 80,
       rows: req.rows || 24,
@@ -110,15 +116,22 @@ export class SessionBroker extends EventEmitter {
       state: 'connecting',
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
-      title: `${req.username}@${hostname}`,
+      title: isClaude ? '🤖 Claude' : `${req.username || 'user'}@${hostname}`,
       persistent: true,
+      session_type: req.session_type,
+      claude_auth_state: isClaude ? 'pending' : undefined,
     };
 
     this.sessions.set(id, session);
 
     // Launch the PTY process (state stays 'connecting' until first data arrives)
     try {
-      const ptyProcess = transportLauncher.launch(session, req.password, req.key_id);
+      let ptyProcess;
+      if (isClaude) {
+        ptyProcess = transportLauncher.launchClaude(session);
+      } else {
+        ptyProcess = transportLauncher.launch(session, req.password, req.key_id);
+      }
       this.wireEvents(session, ptyProcess);
     } catch (err) {
       session.state = 'error';
@@ -160,6 +173,29 @@ export class SessionBroker extends EventEmitter {
         session_id: session.id,
         data,
       });
+
+      // Claude-specific: scan output for auth URL or success message
+      if (session.session_type === 'claude' || session.transport === 'claude') {
+        const urlMatch = CLAUDE_AUTH_URL_RE.exec(data);
+        if (urlMatch) {
+          session.claude_auth_state = 'awaiting_code';
+          session.updated_at = new Date().toISOString();
+          presenceService.broadcastToSession(session.id, {
+            type: 'claude:auth-url',
+            session_id: session.id,
+            url: urlMatch[0],
+          });
+          this.persistSessions();
+        } else if (CLAUDE_AUTH_SUCCESS_RE.test(data) && session.claude_auth_state !== 'authenticated') {
+          session.claude_auth_state = 'authenticated';
+          session.updated_at = new Date().toISOString();
+          presenceService.broadcastToSession(session.id, {
+            type: 'claude:auth-complete',
+            session_id: session.id,
+          });
+          this.persistSessions();
+        }
+      }
     });
 
     ptyProcess.onExit(({ exitCode }: { exitCode: number }) => {

--- a/webmux/backend/src/services/transportLauncher.ts
+++ b/webmux/backend/src/services/transportLauncher.ts
@@ -25,6 +25,11 @@ export class TransportLauncher {
   }
 
   launch(session: Session, password?: string, keyId?: string): pty.IPty {
+    // Claude sessions don't need a remote hostname
+    if (session.transport === 'claude' || session.session_type === 'claude') {
+      return this.launchClaude(session);
+    }
+
     TransportLauncher.validateHostname(session.hostname);
 
     if (session.transport === 'mosh') {
@@ -34,6 +39,25 @@ export class TransportLauncher {
       return this.launchMosh(session, keyId);
     }
     return this.launchSsh(session, password, keyId);
+  }
+
+  launchClaude(session: Session): pty.IPty {
+    const claudeBin = this.findBinary('claude') || 'claude';
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      TERM: 'xterm-256color',
+    };
+
+    const ptyProcess = pty.spawn(claudeBin, [], {
+      name: 'xterm-256color',
+      cols: session.cols,
+      rows: session.rows,
+      cwd: process.env.HOME || '/',
+      env,
+    });
+
+    this.handles.set(session.id, ptyProcess);
+    return ptyProcess;
   }
 
   private launchSsh(session: Session, password?: string, keyId?: string): pty.IPty {

--- a/webmux/backend/src/types/index.ts
+++ b/webmux/backend/src/types/index.ts
@@ -31,8 +31,9 @@ export interface AuthConfig {
   };
 }
 
-export type TransportType = 'ssh' | 'mosh';
+export type TransportType = 'ssh' | 'mosh' | 'claude';
 export type ConnectionState = 'connecting' | 'connected' | 'disconnected' | 'error';
+export type ClaudeAuthState = 'pending' | 'awaiting_code' | 'authenticated';
 
 export interface HostEntry {
   id: string;
@@ -92,6 +93,8 @@ export interface Session {
   updated_at: string;
   title: string;
   persistent: boolean;
+  session_type?: 'ssh' | 'mosh' | 'claude';
+  claude_auth_state?: ClaudeAuthState;
 }
 
 export interface Viewer {
@@ -101,7 +104,7 @@ export interface Viewer {
 }
 
 export interface WebSocketMessage {
-  type: 'input' | 'resize' | 'output' | 'status' | 'focus' | 'viewer_join' | 'viewer_leave' | 'error';
+  type: 'input' | 'resize' | 'output' | 'status' | 'focus' | 'viewer_join' | 'viewer_leave' | 'error' | 'claude:auth-url' | 'claude:auth-complete';
   session_id?: string;
   data?: string;
   cols?: number;
@@ -111,6 +114,7 @@ export interface WebSocketMessage {
   viewer_count?: number;
   focus_owner?: string;
   message?: string;
+  url?: string;
 }
 
 export interface CreateSessionRequest {
@@ -125,5 +129,6 @@ export interface CreateSessionRequest {
   rows?: number;
   row?: number;
   col?: number;
+  session_type?: 'ssh' | 'mosh' | 'claude';
 }
 

--- a/webmux/backend/src/websocket/handler.ts
+++ b/webmux/backend/src/websocket/handler.ts
@@ -6,6 +6,8 @@ import { presenceService } from '../services/presenceService';
 import { requireAuthWs } from '../middleware/auth';
 import { WebSocketMessage } from '../types';
 
+
+
 export function setupWebSocket(wss: WebSocketServer): void {
   wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
     // Extract session ID from path /api/term/:id

--- a/webmux/frontend/src/components/ConnectionDialog.tsx
+++ b/webmux/frontend/src/components/ConnectionDialog.tsx
@@ -2,6 +2,8 @@ import { useState, useEffect, FormEvent } from 'react';
 import { api } from '../utils/api';
 import type { HostEntry, KeyEntry, CreateSessionRequest } from '../types';
 
+type DialogMode = 'ssh' | 'claude';
+
 interface ConnectionDialogProps {
   onConnect: (req: CreateSessionRequest) => Promise<void>;
   onClose: () => void;
@@ -10,6 +12,7 @@ interface ConnectionDialogProps {
 }
 
 export function ConnectionDialog({ onConnect, onClose, suggestedRow, suggestedCol }: ConnectionDialogProps) {
+  const [mode, setMode] = useState<DialogMode>('ssh');
   const [hosts, setHosts] = useState<HostEntry[]>([]);
   const [keys, setKeys] = useState<Pick<KeyEntry, 'id' | 'type' | 'encrypted' | 'description'>[]>([]);
   const [hostname, setHostname] = useState('');
@@ -121,15 +124,66 @@ export function ConnectionDialog({ onConnect, onClose, suggestedRow, suggestedCo
     }
   };
 
+  const handleClaudeConnect = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const req: CreateSessionRequest = {
+        username: 'claude',
+        session_type: 'claude',
+        row: suggestedRow ?? 0,
+        col: suggestedCol ?? 0,
+      };
+      await onConnect(req);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
   const alreadySaved = hosts.some(h => h.hostname === hostname.trim() && h.port === port && (!h.username || h.username === username.trim()));
 
   return (
     <div style={styles.backdrop} onClick={e => e.target === e.currentTarget && onClose()}>
       <div style={styles.dialog}>
         <div style={styles.header}>
-          <span style={styles.title}>Connect to Host</span>
+          <span style={styles.title}>{mode === 'claude' ? '🤖 Launch Claude' : 'Connect to Host'}</span>
           <button style={styles.closeBtn} onClick={onClose}>{'\u2715'}</button>
         </div>
+
+        {/* Mode tabs */}
+        <div style={styles.modeTabs}>
+          <button
+            type="button"
+            style={{ ...styles.modeTab, ...(mode === 'ssh' ? styles.modeTabActive : {}) }}
+            onClick={() => { setMode('ssh'); setError(null); }}
+          >SSH / Mosh</button>
+          <button
+            type="button"
+            style={{ ...styles.modeTab, ...(mode === 'claude' ? styles.modeTabActive : {}) }}
+            onClick={() => { setMode('claude'); setError(null); }}
+          >🤖 Claude</button>
+        </div>
+
+        {mode === 'claude' ? (
+          <div style={styles.claudePane}>
+            <p style={styles.claudeDesc}>
+              Launch a local <strong>Claude CLI</strong> session. If you haven't authenticated yet,
+              an SSO link will appear — click it and paste the code back into the terminal.
+            </p>
+            {error && <div style={styles.error}>{error}</div>}
+            <div style={styles.actions}>
+              <button type="button" style={styles.cancelBtn} onClick={onClose}>Cancel</button>
+              <button
+                type="button"
+                style={styles.connectBtn}
+                disabled={submitting}
+                onClick={handleClaudeConnect}
+              >{submitting ? 'Launching…' : 'Launch Claude'}</button>
+            </div>
+          </div>
+        ) : (
 
         <form onSubmit={handleConnect} style={styles.form}>
           {/* Saved hosts as quick-connect cards */}
@@ -264,12 +318,45 @@ export function ConnectionDialog({ onConnect, onClose, suggestedRow, suggestedCo
             </button>
           </div>
         </form>
+        )}
       </div>
     </div>
   );
 }
 
 const styles: Record<string, React.CSSProperties> = {
+  modeTabs: {
+    display: 'flex',
+    borderBottom: '1px solid #333366',
+    background: '#12122a',
+  },
+  modeTab: {
+    background: 'none',
+    border: 'none',
+    borderBottom: '2px solid transparent',
+    padding: '8px 18px',
+    color: '#888',
+    fontSize: 13,
+    cursor: 'pointer',
+    fontWeight: 500,
+    transition: 'color 0.15s, border-color 0.15s',
+  },
+  modeTabActive: {
+    color: '#e0e0e0',
+    borderBottomColor: '#7c6af7',
+  },
+  claudePane: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 14,
+    padding: 16,
+  },
+  claudeDesc: {
+    color: '#aaa',
+    fontSize: 13,
+    lineHeight: 1.5,
+    margin: 0,
+  },
   backdrop: {
     position: 'fixed',
     inset: 0,

--- a/webmux/frontend/src/components/Terminal.tsx
+++ b/webmux/frontend/src/components/Terminal.tsx
@@ -20,6 +20,7 @@ interface TerminalProps {
   onStateChange: (state: ConnectionState) => void;
   onViewerUpdate: (count: number, focusOwner?: string) => void;
   onFocusGained: () => void;
+  onMessage?: (msg: WebSocketMessage) => void;
 }
 
 export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Terminal({
@@ -29,6 +30,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
   onStateChange,
   onViewerUpdate,
   onFocusGained,
+  onMessage,
 }: TerminalProps, ref) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<XTerm | null>(null);
@@ -53,9 +55,11 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
   const onStateChangeRef = useRef(onStateChange);
   const onViewerUpdateRef = useRef(onViewerUpdate);
   const onFocusGainedRef = useRef(onFocusGained);
+  const onMessageRef = useRef(onMessage);
   useEffect(() => { onStateChangeRef.current = onStateChange; }, [onStateChange]);
   useEffect(() => { onViewerUpdateRef.current = onViewerUpdate; }, [onViewerUpdate]);
   useEffect(() => { onFocusGainedRef.current = onFocusGained; }, [onFocusGained]);
+  useEffect(() => { onMessageRef.current = onMessage; }, [onMessage]);
 
   // routeInput is a stable callback (useCallback with [] deps) that reads
   // broadcastMode from a ref internally — use it directly without a wrapper ref.
@@ -86,6 +90,8 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
         onViewerUpdateRef.current(msg.viewer_count ?? 0, msg.focus_owner);
         break;
       default:
+        // Forward unhandled messages (e.g. claude:auth-url) to parent
+        onMessageRef.current?.(msg);
         break;
     }
   }, []);

--- a/webmux/frontend/src/components/Tile.tsx
+++ b/webmux/frontend/src/components/Tile.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef } from 'react';
 import { Terminal, type TerminalHandle } from './Terminal';
 import { useInputBroadcast } from '../contexts/InputBroadcastContext';
 import { api } from '../utils/api';
-import type { Session, ConnectionState } from '../types';
+import type { Session, ConnectionState, ClaudeAuthState } from '../types';
 
 interface TileProps {
   session: Session;
@@ -24,6 +24,10 @@ export function Tile({ session, fontSize, onClose, onReconnect, onRename, onTitl
   const isExcluded = broadcastExcluded.has(session.id);
   const termHandleRef = useRef<TerminalHandle>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const isClaude = session.session_type === 'claude' || session.transport === 'claude';
+  const [claudeAuthState, setClaudeAuthState] = useState<ClaudeAuthState | undefined>(session.claude_auth_state);
+  const [claudeAuthUrl, setClaudeAuthUrl] = useState<string | undefined>();
+  const [authCodeInput, setAuthCodeInput] = useState('');
 
   const isFocused = focusedSessionId === session.id;
 
@@ -37,6 +41,16 @@ export function Tile({ session, fontSize, onClose, onReconnect, onRename, onTitl
 
   const handleFocusGained = useCallback(() => {
     // Terminal handles setting focusedSessionId via context
+  }, []);
+
+  const handleTerminalMessage = useCallback((msg: import('../types').WebSocketMessage) => {
+    if (msg.type === 'claude:auth-url' && msg.url) {
+      setClaudeAuthState('awaiting_code');
+      setClaudeAuthUrl(msg.url);
+    } else if (msg.type === 'claude:auth-complete') {
+      setClaudeAuthState('authenticated');
+      setClaudeAuthUrl(undefined);
+    }
   }, []);
 
   const handleChromeMouseDown = useCallback((e: React.MouseEvent) => {
@@ -144,7 +158,11 @@ export function Tile({ session, fontSize, onClose, onReconnect, onRename, onTitl
               onDoubleClick={handleTitleDoubleClick}
             >{session.title}</span>
           )}
-          <span style={styles.transport}>{session.transport.toUpperCase()}</span>
+          {isClaude ? (
+            <span style={{ ...styles.transport, background: '#2a1a4a', color: '#b899ff' }}>🤖 CLAUDE</span>
+          ) : (
+            <span style={styles.transport}>{session.transport.toUpperCase()}</span>
+          )}
         </div>
         <div style={styles.chromeRight}>
           {broadcastMode && (
@@ -184,7 +202,61 @@ export function Tile({ session, fontSize, onClose, onReconnect, onRename, onTitl
           onStateChange={handleStateChange}
           onViewerUpdate={handleViewerUpdate}
           onFocusGained={handleFocusGained}
+          onMessage={isClaude ? handleTerminalMessage : undefined}
         />
+        {/* Claude SSO auth overlay */}
+        {isClaude && claudeAuthState === 'awaiting_code' && claudeAuthUrl && (
+          <div style={styles.claudeAuthOverlay}>
+            <div style={styles.claudeAuthCard}>
+              <div style={styles.claudeAuthTitle}>🤖 Claude Authentication Required</div>
+              <p style={styles.claudeAuthDesc}>
+                Open this URL in your browser to authenticate with Claude:
+              </p>
+              <a
+                href={claudeAuthUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={styles.claudeAuthLink}
+              >{claudeAuthUrl}</a>
+              <p style={styles.claudeAuthDesc}>
+                After authenticating, paste the code from the browser here:
+              </p>
+              <div style={styles.claudeAuthInputRow}>
+                <input
+                  style={styles.claudeAuthInput}
+                  type="text"
+                  placeholder="Paste code here…"
+                  value={authCodeInput}
+                  onChange={e => setAuthCodeInput(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter' && authCodeInput.trim()) {
+                      termHandleRef.current?.sendInput(authCodeInput.trim() + '\n');
+                      setAuthCodeInput('');
+                      setClaudeAuthUrl(undefined);
+                      setClaudeAuthState('pending');
+                    }
+                  }}
+                  autoFocus
+                />
+                <button
+                  style={styles.claudeAuthSubmitBtn}
+                  onClick={() => {
+                    if (authCodeInput.trim()) {
+                      termHandleRef.current?.sendInput(authCodeInput.trim() + '\n');
+                      setAuthCodeInput('');
+                      setClaudeAuthUrl(undefined);
+                      setClaudeAuthState('pending');
+                    }
+                  }}
+                >Submit</button>
+              </div>
+              <button
+                style={styles.claudeAuthDismiss}
+                onClick={() => setClaudeAuthUrl(undefined)}
+              >Dismiss (type in terminal manually)</button>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -276,5 +348,80 @@ const styles: Record<string, React.CSSProperties> = {
   termContainer: {
     flex: 1,
     overflow: 'hidden',
+    position: 'relative',
+  },
+  claudeAuthOverlay: {
+    position: 'absolute',
+    inset: 0,
+    background: 'rgba(10, 8, 24, 0.88)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 10,
+    backdropFilter: 'blur(2px)',
+  },
+  claudeAuthCard: {
+    background: '#1a1530',
+    border: '1px solid #5a3fa0',
+    borderRadius: 8,
+    padding: '20px 24px',
+    maxWidth: 480,
+    width: '90%',
+    display: 'flex',
+    flexDirection: 'column' as const,
+    gap: 10,
+    boxShadow: '0 8px 32px rgba(0,0,0,0.6)',
+  },
+  claudeAuthTitle: {
+    fontWeight: 700,
+    fontSize: 15,
+    color: '#e0d8ff',
+  },
+  claudeAuthDesc: {
+    fontSize: 12,
+    color: '#aaa',
+    margin: 0,
+    lineHeight: 1.5,
+  },
+  claudeAuthLink: {
+    fontSize: 11,
+    color: '#9d7bff',
+    wordBreak: 'break-all' as const,
+    textDecoration: 'underline',
+  },
+  claudeAuthInputRow: {
+    display: 'flex',
+    gap: 8,
+  },
+  claudeAuthInput: {
+    flex: 1,
+    background: '#0d0d1a',
+    border: '1px solid #5a3fa0',
+    borderRadius: 4,
+    padding: '7px 10px',
+    color: '#e0e0e0',
+    fontSize: 13,
+    outline: 'none',
+    fontFamily: 'monospace',
+  },
+  claudeAuthSubmitBtn: {
+    background: '#7c6af7',
+    border: 'none',
+    borderRadius: 4,
+    padding: '7px 14px',
+    color: '#fff',
+    fontSize: 13,
+    fontWeight: 600,
+    cursor: 'pointer',
+  },
+  claudeAuthDismiss: {
+    background: 'none',
+    border: 'none',
+    color: '#666',
+    fontSize: 11,
+    cursor: 'pointer',
+    textAlign: 'left' as const,
+    padding: 0,
+    textDecoration: 'underline',
   },
 };

--- a/webmux/frontend/src/types/index.ts
+++ b/webmux/frontend/src/types/index.ts
@@ -1,5 +1,6 @@
-export type TransportType = 'ssh' | 'mosh';
+export type TransportType = 'ssh' | 'mosh' | 'claude';
 export type ConnectionState = 'connecting' | 'connected' | 'disconnected' | 'error';
+export type ClaudeAuthState = 'pending' | 'awaiting_code' | 'authenticated';
 
 export interface Session {
   id: string;
@@ -18,6 +19,8 @@ export interface Session {
   updated_at: string;
   title: string;
   persistent: boolean;
+  session_type?: 'ssh' | 'mosh' | 'claude';
+  claude_auth_state?: ClaudeAuthState;
 }
 
 export interface HostEntry {
@@ -37,7 +40,7 @@ export interface AuthStatus {
 }
 
 export interface WebSocketMessage {
-  type: 'input' | 'resize' | 'output' | 'status' | 'focus' | 'viewer_join' | 'viewer_leave' | 'error';
+  type: 'input' | 'resize' | 'output' | 'status' | 'focus' | 'viewer_join' | 'viewer_leave' | 'error' | 'claude:auth-url' | 'claude:auth-complete';
   session_id?: string;
   data?: string;
   cols?: number;
@@ -47,6 +50,7 @@ export interface WebSocketMessage {
   viewer_count?: number;
   focus_owner?: string;
   message?: string;
+  url?: string;
 }
 
 export interface CreateSessionRequest {
@@ -61,6 +65,7 @@ export interface CreateSessionRequest {
   rows?: number;
   row?: number;
   col?: number;
+  session_type?: 'ssh' | 'mosh' | 'claude';
 }
 
 export interface KeyEntry {


### PR DESCRIPTION
Adds first-class Claude CLI session type to webmux.

## Changes
- New 'claude' transport type
- Claude tab in ConnectionDialog
- Auth flow overlay (guides SSO: shows auth URL, accepts paste-back code)
- 🤖 badge in tile header for claude sessions
- WebSocket events: claude:auth-url, claude:auth-complete

Closes #9 (part 2 — the Claude session template)