### PR TITLE
Fix MCP server config schema in .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,10 +1,8 @@
 {
   "mcpServers": {
     "responsible-vibe-mcp": {
-      "command": [
-        "npx",
-        "@codemcp/workflows@latest"
-      ]
+      "command": "npx",
+      "args": ["@codemcp/workflows@latest"]
     }
   }
 }


### PR DESCRIPTION
## Summary

The `command` field in `.mcp.json` was an array but the MCP schema expects it as a string with a separate `args` array.

Before: `"command": ["npx", "@codemcp/workflows@latest"]`
After: `"command": "npx", "args": ["@codemcp/workflows@latest"]`

## Test plan

- [ ] `/doctor` no longer shows a parse error for `.mcp.json`