### PR TITLE
feat: add client-side color themes from .itermcolors files

### DIFF
--- a/webmux/frontend/public/themes/Amber.itermcolors
+++ b/webmux/frontend/public/themes/Amber.itermcolors
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Ansi 0 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.0</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.0</real>
+		<key>Red Component</key>
+		<real>0.0</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.016267113387584686</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.0</real>
+		<key>Red Component</key>
+		<real>0.7449747920036316</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.0</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>1.0</real>
+		<key>Red Component</key>
+		<real>0.0</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.0</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>1.0</real>
+		<key>Red Component</key>
+		<real>1.0</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.6836735010147095</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.48093628883361816</real>
+		<key>Red Component</key>
+		<real>0.29328519105911255</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>1.0</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.0</real>
+		<key>Red Component</key>
+		<real>1.0</real>
+	</dict>
+	<key>Ansi 14 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>1.0</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8911494612693787</real>
+		<key>Red Component</key>
+		<real>0.1627073884010315</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>1.0</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>1.0</real>
+		<key>Red Component</key>
+		<real>1.0</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.015027351677417755</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7780846357345581</real>
+		<key>Red Component</key>
+		<real>0.10219534486532211</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.031274694949388504</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.769845724105835</real>
+		<key>Red Component</key>
+		<real>0.7564911842346191</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.8750778436660767</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.0</real>
+		<key>Red Component</key>
+		<real>0.0</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.754934549331665</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.0</real>
+		<key>Red Component</key>
+		<real>0.7440600991249084</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.7548806667327881</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7639495134353638</real>
+		<key>Red Component</key>
+		<real>0.09763424843549728</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.949999988079071</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.949999988079071</real>
+		<key>Red Component</key>
+		<real>0.949999988079071</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.3333333432674408</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.3333333432674408</real>
+		<key>Red Component</key>
+		<real>0.3333333432674408</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.0</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.0</real>
+		<key>Red Component</key>
+		<real>1.0</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.1729317456483841</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.1729317456483841</real>
+		<key>Red Component</key>
+		<real>0.1729317456483841</real>
+	</dict>
+	<key>Bold Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.0</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.2850455</real>
+		<key>Red Component</key>
+		<real>1.0</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.25086853</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.88556707</real>
+		<key>Red Component</key>
+		<real>0.96763563</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.25086853</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.88556707</real>
+		<key>Red Component</key>
+		<real>0.96763563</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.027508378</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.56375414</real>
+		<key>Red Component</key>
+		<real>1.0</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.027508378</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.56375414</real>
+		<key>Red Component</key>
+		<real>1.0</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.057676122</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.18036725</real>
+		<key>Red Component</key>
+		<real>0.375</real>
+	</dict>
+</dict>
+</plist>

--- a/webmux/frontend/public/themes/Borland.itermcolors
+++ b/webmux/frontend/public/themes/Borland.itermcolors
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Ansi 0 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.24268999695777893</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.24268999695777893</real>
+		<key>Red Component</key>
+		<real>0.24268993735313416</real>
+	</dict>
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.30578550696372986</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.3274945020675659</real>
+		<key>Red Component</key>
+		<real>0.9881104230880737</real>
+	</dict>
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.6105697751045227</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>1.0</real>
+		<key>Red Component</key>
+		<real>0.774111270904541</real>
+	</dict>
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.7560676336288452</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>1.0</real>
+		<key>Red Component</key>
+		<real>1.0</real>
+	</dict>
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.9970614910125732</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8274970054626465</real>
+		<key>Red Component</key>
+		<real>0.6577650904655457</real>
+	</dict>
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.9950423240661621</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.5108298659324646</real>
+		<key>Red Component</key>
+		<real>0.9898742437362671</real>
+	</dict>
+	<key>Ansi 14 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.9958049058914185</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.8413405418395996</real>
+		<key>Red Component</key>
+		<real>0.8460030555725098</real>
+	</dict>
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>1.0</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>1.0</real>
+		<key>Red Component</key>
+		<real>1.0</real>
+	</dict>
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.30621206760406494</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>1.0</real>
+		<key>Red Component</key>
+		<real>0.60835200548172</real>
+	</dict>
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.6570210456848145</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>1.0</real>
+		<key>Red Component</key>
+		<real>1.0</real>
+	</dict>
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.9940603971481323</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7456222772598267</real>
+		<key>Red Component</key>
+		<real>0.523090124130249</real>
+	</dict>
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.9894102811813354</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.31793057918548584</real>
+		<key>Red Component</key>
+		<real>0.9873939752578735</real>
+	</dict>
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.9942706823348999</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.7125993967056274</real>
+		<key>Red Component</key>
+		<real>0.7272083163261414</real>
+	</dict>
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.9168906211853027</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.916890561580658</real>
+		<key>Red Component</key>
+		<real>0.916890561580658</real>
+	</dict>
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.41072720289230347</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.41072720289230347</real>
+		<key>Red Component</key>
+		<real>0.41072720289230347</real>
+	</dict>
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.6298667192459106</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.6482499837875366</real>
+		<key>Red Component</key>
+		<real>0.9925848245620728</real>
+	</dict>
+	<key>Background Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.5756188631057739</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.0</real>
+		<key>Red Component</key>
+		<real>0.0</real>
+	</dict>
+	<key>Bold Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.2444065809249878</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>1.0</real>
+		<key>Red Component</key>
+		<real>1.0</real>
+	</dict>
+	<key>Cursor Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.30628976225852966</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.5778800249099731</real>
+		<key>Red Component</key>
+		<real>0.9915700554847717</real>
+	</dict>
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.30628976225852966</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.5778800249099731</real>
+		<key>Red Component</key>
+		<real>0.9915700554847717</real>
+	</dict>
+	<key>Foreground Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.2444065809249878</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>1.0</real>
+		<key>Red Component</key>
+		<real>1.0</real>
+	</dict>
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.2444065809249878</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>1.0</real>
+		<key>Red Component</key>
+		<real>1.0</real>
+	</dict>
+	<key>Selection Color</key>
+	<dict>
+		<key>Alpha Component</key>
+		<real>1.0</real>
+		<key>Blue Component</key>
+		<real>0.5766573548316956</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+		<key>Green Component</key>
+		<real>0.5766573548316956</real>
+		<key>Red Component</key>
+		<real>0.5766573548316956</real>
+	</dict>
+</dict>
+</plist>

--- a/webmux/frontend/public/themes/index.json
+++ b/webmux/frontend/public/themes/index.json
@@ -1,0 +1,6 @@
+{
+  "themes": [
+    { "name": "Amber", "file": "Amber.itermcolors" },
+    { "name": "Borland", "file": "Borland.itermcolors" }
+  ]
+}

--- a/webmux/frontend/src/App.tsx
+++ b/webmux/frontend/src/App.tsx
@@ -9,6 +9,8 @@ import { RegisterDialog } from './components/RegisterDialog';
 import { InputBroadcastProvider } from './contexts/InputBroadcastContext';
 import { WorkspacePaneProvider, useWorkspacePane } from './contexts/WorkspacePaneContext';
 import { api } from './utils/api';
+import type { NamedTheme } from './types';
+import { loadBundledThemes, loadGlobalTheme, saveGlobalTheme } from './utils/themes';
 
 interface AuthenticatedAppProps {
   auth: AuthState;
@@ -23,6 +25,9 @@ interface AuthenticatedAppProps {
   showRegister: boolean;
   onRegisterClose: () => void;
   onAccountCreated: (username: string) => void;
+  themes: NamedTheme[];
+  globalTheme: string | null;
+  onGlobalThemeChange: (name: string | null) => void;
 }
 
 function AuthenticatedApp({
@@ -38,6 +43,9 @@ function AuthenticatedApp({
   showRegister,
   onRegisterClose,
   onAccountCreated,
+  themes,
+  globalTheme,
+  onGlobalThemeChange,
 }: AuthenticatedAppProps) {
   const { activePane } = useWorkspacePane();
 
@@ -53,11 +61,14 @@ function AuthenticatedApp({
         onNewAccount={onNewAccount}
         secureMode={secureMode}
         currentUser={currentUser}
+        themes={themes}
+        globalTheme={globalTheme}
+        onGlobalThemeChange={onGlobalThemeChange}
       />
 
       <div style={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
         <div style={{ display: activePane === 'terminals' ? 'flex' : 'none', height: '100%', flexDirection: 'column' }}>
-          <Workspace fontSize={fontSize} termCols={termCols} termRows={termRows} />
+          <Workspace fontSize={fontSize} termCols={termCols} termRows={termRows} themes={themes} globalTheme={globalTheme} />
         </div>
         <div style={{ display: activePane === 'desktops' ? 'flex' : 'none', height: '100%', flexDirection: 'column' }}>
           <GraphicsWorkspace />
@@ -96,6 +107,8 @@ export default function App() {
   const [termRows, setTermRows] = useState(24);
   const [showRegister, setShowRegister] = useState(false);
   const [secureMode, setSecureMode] = useState(true);
+  const [themes, setThemes] = useState<NamedTheme[]>([]);
+  const [globalTheme, setGlobalTheme] = useState<string | null>(() => loadGlobalTheme());
 
   const currentUser = useMemo(() => auth.isAuthenticated ? parseTokenUser() : null, [auth.isAuthenticated]);
 
@@ -106,6 +119,12 @@ export default function App() {
       setTermCols(config.app.default_term.cols);
       setTermRows(config.app.default_term.rows);
     }).catch(() => {});
+    loadBundledThemes().then(setThemes).catch(() => {});
+  }, []);
+
+  const handleGlobalThemeChange = useCallback((name: string | null) => {
+    setGlobalTheme(name);
+    saveGlobalTheme(name);
   }, []);
 
   const handleFontSizeChange = useCallback((size: number) => {
@@ -152,6 +171,9 @@ export default function App() {
           showRegister={showRegister}
           onRegisterClose={() => setShowRegister(false)}
           onAccountCreated={handleAccountCreated}
+          themes={themes}
+          globalTheme={globalTheme}
+          onGlobalThemeChange={handleGlobalThemeChange}
         />
       </WorkspacePaneProvider>
     </InputBroadcastProvider>

--- a/webmux/frontend/src/components/Terminal.tsx
+++ b/webmux/frontend/src/components/Terminal.tsx
@@ -3,9 +3,32 @@ import { Terminal as XTerm } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
-import type { WebSocketMessage, ConnectionState } from '../types';
+import type { WebSocketMessage, ConnectionState, TerminalTheme } from '../types';
 import { useWebSocket } from '../hooks/useWebSocket';
 import { useInputBroadcast } from '../contexts/InputBroadcastContext';
+
+export const DEFAULT_TERMINAL_THEME: TerminalTheme = {
+  background: '#0d0d1a',
+  foreground: '#e0e0e0',
+  cursor: '#7c6af7',
+  selectionBackground: 'rgba(124, 106, 247, 0.3)' as unknown as string,
+  black: '#1a1a2e',
+  brightBlack: '#333333',
+  red: '#ff5555',
+  brightRed: '#ff8080',
+  green: '#50fa7b',
+  brightGreen: '#80ffaa',
+  yellow: '#f1fa8c',
+  brightYellow: '#ffff80',
+  blue: '#6272a4',
+  brightBlue: '#8080ff',
+  magenta: '#ff79c6',
+  brightMagenta: '#ffaadd',
+  cyan: '#8be9fd',
+  brightCyan: '#aaeeff',
+  white: '#f8f8f2',
+  brightWhite: '#ffffff',
+};
 
 export interface TerminalHandle {
   scrollToBottom: () => void;
@@ -20,6 +43,7 @@ interface TerminalProps {
   onStateChange: (state: ConnectionState) => void;
   onViewerUpdate: (count: number, focusOwner?: string) => void;
   onFocusGained: () => void;
+  theme?: TerminalTheme | null;
 }
 
 export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Terminal({
@@ -29,6 +53,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
   onStateChange,
   onViewerUpdate,
   onFocusGained,
+  theme,
 }: TerminalProps, ref) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<XTerm | null>(null);
@@ -115,28 +140,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     if (!containerRef.current) return;
 
     const term = new XTerm({
-      theme: {
-        background: '#0d0d1a',
-        foreground: '#e0e0e0',
-        cursor: '#7c6af7',
-        selectionBackground: 'rgba(124, 106, 247, 0.3)',
-        black: '#1a1a2e',
-        brightBlack: '#333333',
-        red: '#ff5555',
-        brightRed: '#ff8080',
-        green: '#50fa7b',
-        brightGreen: '#80ffaa',
-        yellow: '#f1fa8c',
-        brightYellow: '#ffff80',
-        blue: '#6272a4',
-        brightBlue: '#8080ff',
-        magenta: '#ff79c6',
-        brightMagenta: '#ffaadd',
-        cyan: '#8be9fd',
-        brightCyan: '#aaeeff',
-        white: '#f8f8f2',
-        brightWhite: '#ffffff',
-      },
+      theme: { ...DEFAULT_TERMINAL_THEME, ...(theme || {}) },
       fontFamily: 'Consolas, Menlo, "DejaVu Sans Mono", monospace',
       fontSize,
       cursorBlink: true,
@@ -212,6 +216,13 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
       fitAddonRef.current?.fit();
     }
   }, [fontSize]);
+
+  // Apply theme changes without tearing down the terminal (preserves scrollback).
+  useEffect(() => {
+    if (termRef.current) {
+      termRef.current.options.theme = { ...DEFAULT_TERMINAL_THEME, ...(theme || {}) };
+    }
+  }, [theme]);
 
   // When broadcast mode is enabled, re-focus the active terminal so keyboard
   // input flows immediately without requiring the user to click again.

--- a/webmux/frontend/src/components/Tile.tsx
+++ b/webmux/frontend/src/components/Tile.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef } from 'react';
 import { Terminal, type TerminalHandle } from './Terminal';
 import { useInputBroadcast } from '../contexts/InputBroadcastContext';
 import { api } from '../utils/api';
-import type { Session, ConnectionState } from '../types';
+import type { Session, ConnectionState, NamedTheme } from '../types';
 
 interface TileProps {
   session: Session;
@@ -13,9 +13,13 @@ interface TileProps {
   onTitleMouseDown?: (sessionId: string, e: React.MouseEvent) => void;
   isDragging?: boolean;
   isDropTarget?: boolean;
+  themes?: NamedTheme[];
+  globalTheme?: string | null;
+  themeOverride?: string | null;
+  onThemeChange?: (id: string, theme: string | null) => void;
 }
 
-export function Tile({ session, fontSize, onClose, onReconnect, onRename, onTitleMouseDown, isDragging, isDropTarget }: TileProps) {
+export function Tile({ session, fontSize, onClose, onReconnect, onRename, onTitleMouseDown, isDragging, isDropTarget, themes = [], globalTheme = null, themeOverride = null, onThemeChange }: TileProps) {
   const [state, setState] = useState<ConnectionState>(session.state);
   const [viewerCount, setViewerCount] = useState(1);
   const [editing, setEditing] = useState(false);
@@ -168,6 +172,20 @@ export function Tile({ session, fontSize, onClose, onReconnect, onRename, onTitl
             onClick={() => termHandleRef.current?.scrollToBottom()}
             title="Scroll to bottom"
           >&#8595;</button>
+          {themes.length > 0 && onThemeChange && (
+            <select
+              style={styles.themeSelect}
+              value={themeOverride ?? ''}
+              onChange={e => onThemeChange(session.id, e.target.value || null)}
+              title={themeOverride ? `Theme override: ${themeOverride}` : `Using global theme${globalTheme ? ` (${globalTheme})` : ''}`}
+              onMouseDown={e => e.stopPropagation()}
+            >
+              <option value="">{globalTheme ? `\u25bd ${globalTheme}` : '\u25bd (default)'}</option>
+              {themes.map(t => (
+                <option key={t.name} value={t.name}>{t.name}</option>
+              ))}
+            </select>
+          )}
           {(state === 'disconnected' || state === 'error') && (
             <button style={{ ...styles.chromeBtn, color: '#caaa4a' }} onClick={() => onReconnect(session.id)} title="Reconnect">{'\u21ba'}</button>
           )}
@@ -184,6 +202,7 @@ export function Tile({ session, fontSize, onClose, onReconnect, onRename, onTitl
           onStateChange={handleStateChange}
           onViewerUpdate={handleViewerUpdate}
           onFocusGained={handleFocusGained}
+          theme={themes.find(t => t.name === (themeOverride ?? globalTheme))?.theme}
         />
       </div>
     </div>
@@ -272,6 +291,16 @@ const styles: Record<string, React.CSSProperties> = {
     padding: '2px 4px',
     borderRadius: 2,
     lineHeight: 1,
+  },
+  themeSelect: {
+    background: '#1a1a3a',
+    color: '#aaa',
+    border: '1px solid #333366',
+    borderRadius: 3,
+    fontSize: 10,
+    padding: '1px 4px',
+    cursor: 'pointer',
+    maxWidth: 100,
   },
   termContainer: {
     flex: 1,

--- a/webmux/frontend/src/components/TopBar.tsx
+++ b/webmux/frontend/src/components/TopBar.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { AuthState } from '../hooks/useAuth';
+import type { NamedTheme } from '../types';
 import { useInputBroadcast } from '../contexts/InputBroadcastContext';
 import { useWorkspacePane } from '../contexts/WorkspacePaneContext';
 import { HelpDialog } from './HelpDialog';
@@ -14,9 +15,12 @@ interface TopBarProps {
   onNewAccount: () => void;
   secureMode: boolean;
   currentUser: string | null;
+  themes?: NamedTheme[];
+  globalTheme?: string | null;
+  onGlobalThemeChange?: (name: string | null) => void;
 }
 
-export function TopBar({ auth, fontSize, onFontSizeChange, termCols, termRows, onTermSizeChange, onNewAccount, secureMode, currentUser }: TopBarProps) {
+export function TopBar({ auth, fontSize, onFontSizeChange, termCols, termRows, onTermSizeChange, onNewAccount, secureMode, currentUser, themes = [], globalTheme = null, onGlobalThemeChange }: TopBarProps) {
   const { broadcastMode, setBroadcastMode } = useInputBroadcast();
   const { activePane, setActivePane } = useWorkspacePane();
   const [showHelp, setShowHelp] = useState(false);
@@ -89,6 +93,20 @@ export function TopBar({ auth, fontSize, onFontSizeChange, termCols, termRows, o
               A+
             </button>
           </div>
+        )}
+
+        {activePane === 'terminals' && themes.length > 0 && onGlobalThemeChange && (
+          <select
+            style={styles.themeSelect}
+            value={globalTheme ?? ''}
+            onChange={e => onGlobalThemeChange(e.target.value || null)}
+            title="Global terminal theme (per-session override available on each tile)"
+          >
+            <option value="">Default</option>
+            {themes.map(t => (
+              <option key={t.name} value={t.name}>{t.name}</option>
+            ))}
+          </select>
         )}
 
         {activePane === 'terminals' && (
@@ -213,6 +231,16 @@ const styles: Record<string, React.CSSProperties> = {
     display: 'flex',
     alignItems: 'center',
     gap: 4,
+  },
+  themeSelect: {
+    background: '#1a1a3a',
+    color: '#aaa',
+    border: '1px solid #333366',
+    borderRadius: 4,
+    fontSize: 12,
+    padding: '3px 6px',
+    cursor: 'pointer',
+    maxWidth: 140,
   },
   termSize: {
     color: '#aaa',

--- a/webmux/frontend/src/components/Workspace.tsx
+++ b/webmux/frontend/src/components/Workspace.tsx
@@ -2,12 +2,15 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { Tile } from './Tile';
 import { ConnectionDialog } from './ConnectionDialog';
 import { api } from '../utils/api';
-import type { Session, CreateSessionRequest } from '../types';
+import type { Session, CreateSessionRequest, NamedTheme } from '../types';
+import { loadSessionThemeOverrides, saveSessionThemeOverrides } from '../utils/themes';
 
 interface WorkspaceProps {
   fontSize: number;
   termCols: number;
   termRows: number;
+  themes?: NamedTheme[];
+  globalTheme?: string | null;
 }
 
 const GAP = 8;
@@ -95,10 +98,11 @@ function AddCell({ row, col, isEmpty, onClick }: {
   );
 }
 
-export function Workspace({ fontSize, termCols, termRows }: WorkspaceProps) {
+export function Workspace({ fontSize, termCols, termRows, themes = [], globalTheme = null }: WorkspaceProps) {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
   const [dialogPos, setDialogPos] = useState<{ row: number; col: number } | null>(null);
+  const [themeOverrides, setThemeOverrides] = useState<Map<string, string>>(() => loadSessionThemeOverrides());
 
 
   // Drag state
@@ -148,6 +152,16 @@ export function Workspace({ fontSize, termCols, termRows }: WorkspaceProps) {
     api.renameSession(id, title).catch(err => {
       console.error('Rename error:', err);
       api.getSessions().then(setSessions);
+    });
+  }, []);
+
+  const handleThemeChange = useCallback((id: string, theme: string | null) => {
+    setThemeOverrides(prev => {
+      const next = new Map(prev);
+      if (theme) next.set(id, theme);
+      else next.delete(id);
+      saveSessionThemeOverrides(next);
+      return next;
     });
   }, []);
 
@@ -292,6 +306,10 @@ export function Workspace({ fontSize, termCols, termRows }: WorkspaceProps) {
               onTitleMouseDown={handleTitleMouseDown}
               isDragging={draggingId === session.id}
               isDropTarget={dropTarget?.row === session.row && dropTarget?.col === session.col}
+              themes={themes}
+              globalTheme={globalTheme}
+              themeOverride={themeOverrides.get(session.id) ?? null}
+              onThemeChange={handleThemeChange}
             />
           </div>
         ))}

--- a/webmux/frontend/src/types/index.ts
+++ b/webmux/frontend/src/types/index.ts
@@ -23,6 +23,35 @@ export interface Session {
   persistent: boolean;
 }
 
+export interface TerminalTheme {
+  background?: string;
+  foreground?: string;
+  cursor?: string;
+  cursorAccent?: string;
+  selectionBackground?: string;
+  black?: string;
+  red?: string;
+  green?: string;
+  yellow?: string;
+  blue?: string;
+  magenta?: string;
+  cyan?: string;
+  white?: string;
+  brightBlack?: string;
+  brightRed?: string;
+  brightGreen?: string;
+  brightYellow?: string;
+  brightBlue?: string;
+  brightMagenta?: string;
+  brightCyan?: string;
+  brightWhite?: string;
+}
+
+export interface NamedTheme {
+  name: string;
+  theme: TerminalTheme;
+}
+
 export interface HostEntry {
   id: string;
   hostname: string;

--- a/webmux/frontend/src/utils/themes.ts
+++ b/webmux/frontend/src/utils/themes.ts
@@ -1,0 +1,109 @@
+import type { NamedTheme, TerminalTheme } from '../types';
+
+const ITERM_TO_XTERM: Record<string, keyof TerminalTheme> = {
+  'Ansi 0 Color': 'black',
+  'Ansi 1 Color': 'red',
+  'Ansi 2 Color': 'green',
+  'Ansi 3 Color': 'yellow',
+  'Ansi 4 Color': 'blue',
+  'Ansi 5 Color': 'magenta',
+  'Ansi 6 Color': 'cyan',
+  'Ansi 7 Color': 'white',
+  'Ansi 8 Color': 'brightBlack',
+  'Ansi 9 Color': 'brightRed',
+  'Ansi 10 Color': 'brightGreen',
+  'Ansi 11 Color': 'brightYellow',
+  'Ansi 12 Color': 'brightBlue',
+  'Ansi 13 Color': 'brightMagenta',
+  'Ansi 14 Color': 'brightCyan',
+  'Ansi 15 Color': 'brightWhite',
+  'Background Color': 'background',
+  'Foreground Color': 'foreground',
+  'Cursor Color': 'cursor',
+  'Cursor Text Color': 'cursorAccent',
+  'Selection Color': 'selectionBackground',
+};
+
+export function parseItermColors(xml: string): TerminalTheme {
+  const theme: TerminalTheme = {};
+  const entryRe = /<key>([^<]+)<\/key>\s*<dict>([\s\S]*?)<\/dict>/g;
+  let m: RegExpExecArray | null;
+  while ((m = entryRe.exec(xml)) !== null) {
+    const itermKey = m[1].trim();
+    const xtermKey = ITERM_TO_XTERM[itermKey];
+    if (!xtermKey) continue;
+    const body = m[2];
+    const readComponent = (name: string): number | null => {
+      const rm = new RegExp(`<key>${name}<\\/key>\\s*<real>([^<]+)<\\/real>`).exec(body);
+      return rm ? parseFloat(rm[1]) : null;
+    };
+    const r = readComponent('Red Component');
+    const g = readComponent('Green Component');
+    const b = readComponent('Blue Component');
+    if (r === null || g === null || b === null) continue;
+    const to255 = (f: number) => Math.max(0, Math.min(255, Math.round(f * 255)));
+    theme[xtermKey] = `#${to255(r).toString(16).padStart(2, '0')}${to255(g).toString(16).padStart(2, '0')}${to255(b).toString(16).padStart(2, '0')}`;
+  }
+  return theme;
+}
+
+interface ThemeIndexEntry {
+  name: string;
+  file: string;
+}
+
+export async function loadBundledThemes(): Promise<NamedTheme[]> {
+  const idxRes = await fetch('/themes/index.json', { cache: 'no-cache' });
+  if (!idxRes.ok) return [];
+  const idx = await idxRes.json() as { themes: ThemeIndexEntry[] };
+  const results: NamedTheme[] = [];
+  for (const entry of idx.themes) {
+    try {
+      const res = await fetch(`/themes/${encodeURIComponent(entry.file)}`, { cache: 'no-cache' });
+      if (!res.ok) continue;
+      const xml = await res.text();
+      results.push({ name: entry.name, theme: parseItermColors(xml) });
+    } catch {
+      // ignore a single broken theme; keep others
+    }
+  }
+  results.sort((a, b) => a.name.localeCompare(b.name));
+  return results;
+}
+
+const GLOBAL_KEY = 'webmux_global_theme';
+const OVERRIDES_KEY = 'webmux_session_themes';
+
+export function loadGlobalTheme(): string | null {
+  try {
+    return localStorage.getItem(GLOBAL_KEY) || null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveGlobalTheme(name: string | null): void {
+  try {
+    if (name) localStorage.setItem(GLOBAL_KEY, name);
+    else localStorage.removeItem(GLOBAL_KEY);
+  } catch { /* quota or unavailable */ }
+}
+
+export function loadSessionThemeOverrides(): Map<string, string> {
+  try {
+    const raw = localStorage.getItem(OVERRIDES_KEY);
+    if (!raw) return new Map();
+    const obj = JSON.parse(raw) as Record<string, string>;
+    return new Map(Object.entries(obj));
+  } catch {
+    return new Map();
+  }
+}
+
+export function saveSessionThemeOverrides(map: Map<string, string>): void {
+  try {
+    const obj: Record<string, string> = {};
+    map.forEach((v, k) => { obj[k] = v; });
+    localStorage.setItem(OVERRIDES_KEY, JSON.stringify(obj));
+  } catch { /* quota or unavailable */ }
+}


### PR DESCRIPTION
## Summary
- Adds a global terminal-color-theme picker to the top bar and a per-session override select in each tile's chrome.
- Themes ship as `.itermcolors` files under `webmux/frontend/public/themes/` and are parsed client-side. Two starters: **Amber** (CRT amber) and **Borland** (classic DOS blue).
- Selections persist in `localStorage` (`webmux_global_theme`, `webmux_session_themes`), so **no backend changes are needed**.

## How it works
- `utils/themes.ts` fetches `/themes/index.json`, loads each listed `.itermcolors`, and parses it into xterm.js `ITheme` shape using a tiny regex walker (no new dependencies).
- `Terminal.tsx` accepts a `theme` prop and updates `term.options.theme` on change — no terminal rebuild, scrollback is preserved.
- Effective theme resolution: `session-override ?? global ?? built-in DEFAULT_TERMINAL_THEME` (the existing palette, just factored into an exported constant).

## Adding a theme
Drop a `.itermcolors` file into `webmux/frontend/public/themes/`, update `index.json`, rebuild the frontend. No server restart required (the Express static handler serves whatever is in `frontend/dist/` at request time).

## Caveats
- No cross-device sync: selections are per-browser via `localStorage`.
- Fonts are intentionally out of scope — all panes share geometry today, so font-per-theme would require wider layout changes.
- `.terminal` (Mac Terminal) files use NSArchiver-encoded colors, which are painful to parse in JS. Converting `.terminal` → `.itermcolors` is a one-time local step (plenty of iTerm2 theme galleries exist if you want more variety).

## Test plan
- [x] `make test` — backend 174, frontend 129, e2e 7, all green
- [x] TypeScript strict check passes on both workspaces
- [ ] Manual: pick a global theme, confirm all tiles recolor live
- [ ] Manual: override one tile to a different theme, confirm only that tile changes
- [ ] Manual: reload the page, confirm selections persist
- [ ] Manual: drop a new `.itermcolors` into `public/themes/`, update `index.json`, rebuild — new theme appears