### PR TITLE
feat: add workspace minimap for quick navigation

### DIFF
--- a/webmux/frontend/src/components/Workspace.tsx
+++ b/webmux/frontend/src/components/Workspace.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Tile } from './Tile';
+import { WorkspaceMinimap } from './WorkspaceMinimap';
 import { ConnectionDialog } from './ConnectionDialog';
 import { api } from '../utils/api';
 import type { Session, CreateSessionRequest } from '../types';
@@ -106,6 +107,7 @@ export function Workspace({ fontSize, termCols, termRows }: WorkspaceProps) {
   const [dropTarget, setDropTarget] = useState<{ row: number; col: number } | null>(null);
   const [ghostPos, setGhostPos] = useState({ x: 0, y: 0 });
   const gridRef = useRef<HTMLDivElement>(null);
+  const outerRef = useRef<HTMLDivElement>(null);
 
   // Refs for use in event handlers (avoid stale closures)
   const sessionsRef = useRef<Session[]>([]);
@@ -261,7 +263,8 @@ export function Workspace({ fontSize, termCols, termRows }: WorkspaceProps) {
   }
 
   return (
-    <div style={styles.outer}>
+    <div style={styles.shell}>
+    <div ref={outerRef} style={styles.outer}>
       <div style={styles.hint}>Hold Shift to scroll</div>
       <div
         ref={gridRef}
@@ -332,10 +335,27 @@ export function Workspace({ fontSize, termCols, termRows }: WorkspaceProps) {
         />
       )}
     </div>
+    <WorkspaceMinimap
+      scrollRef={outerRef}
+      sessions={sessions}
+      numCols={numCols}
+      numRows={numRows}
+      tileWidth={tile.w}
+      tileHeight={tile.h}
+      gap={GAP}
+    />
+    </div>
   );
 }
 
 const styles: Record<string, React.CSSProperties> = {
+  shell: {
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    minHeight: 0,
+  },
   outer: {
     flex: 1,
     overflowX: 'auto',

--- a/webmux/frontend/src/components/WorkspaceMinimap.tsx
+++ b/webmux/frontend/src/components/WorkspaceMinimap.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useRef, useState, useCallback, RefObject } from 'react';
+import type { Session } from '../types';
+
+interface WorkspaceMinimapProps {
+  scrollRef: RefObject<HTMLDivElement | null>;
+  sessions: Session[];
+  numCols: number;
+  numRows: number;
+  // Tile pixel dimensions INCLUDING neither gap nor padding — intrinsic cell size.
+  tileWidth: number;
+  tileHeight: number;
+  gap: number;
+}
+
+const MINIMAP_W = 180;
+const MINIMAP_H_MAX = 140;
+const PAD = 12;
+
+export function WorkspaceMinimap({ scrollRef, sessions, numCols, numRows, tileWidth, tileHeight, gap }: WorkspaceMinimapProps) {
+  const [viewport, setViewport] = useState({ x: 0, y: 0, w: 0, h: 0 });
+  const [visible, setVisible] = useState(false);
+  const svgRef = useRef<SVGSVGElement>(null);
+
+  const gridW = numCols * tileWidth + (numCols + 1) * gap;
+  const gridH = numRows * tileHeight + (numRows + 1) * gap;
+
+  // Derive minimap pixel size: preserve grid aspect ratio, cap dimensions.
+  const aspect = gridH / Math.max(1, gridW);
+  const mmW = MINIMAP_W;
+  const mmH = Math.max(50, Math.min(MINIMAP_H_MAX, Math.round(MINIMAP_W * aspect)));
+  const scaleX = mmW / Math.max(1, gridW);
+  const scaleY = mmH / Math.max(1, gridH);
+
+  // Track scroll + size changes on the outer scroll container.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const sync = () => {
+      setViewport({ x: el.scrollLeft, y: el.scrollTop, w: el.clientWidth, h: el.clientHeight });
+      setVisible(el.scrollWidth > el.clientWidth + 1 || el.scrollHeight > el.clientHeight + 1);
+    };
+    sync();
+    el.addEventListener('scroll', sync, { passive: true });
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(sync) : null;
+    ro?.observe(el);
+    window.addEventListener('resize', sync);
+    return () => {
+      el.removeEventListener('scroll', sync);
+      window.removeEventListener('resize', sync);
+      ro?.disconnect();
+    };
+  }, [scrollRef, sessions.length, numCols, numRows]);
+
+  const jumpTo = useCallback((clientX: number, clientY: number) => {
+    const el = scrollRef.current;
+    const svg = svgRef.current;
+    if (!el || !svg) return;
+    const rect = svg.getBoundingClientRect();
+    // Map click in minimap-pixels back to grid-pixels, then center viewport.
+    const mx = (clientX - rect.left) / scaleX;
+    const my = (clientY - rect.top) / scaleY;
+    const targetLeft = Math.max(0, Math.min(el.scrollWidth - el.clientWidth, mx - el.clientWidth / 2));
+    const targetTop = Math.max(0, Math.min(el.scrollHeight - el.clientHeight, my - el.clientHeight / 2));
+    el.scrollTo({ left: targetLeft, top: targetTop, behavior: 'smooth' });
+  }, [scrollRef, scaleX, scaleY]);
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault();
+    jumpTo(e.clientX, e.clientY);
+    const onMove = (me: MouseEvent) => jumpTo(me.clientX, me.clientY);
+    const onUp = () => {
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    };
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  };
+
+  if (!visible || sessions.length === 0) return null;
+
+  // Viewport rect clamped so it stays visible at the edges of the minimap.
+  const vpX = viewport.x * scaleX;
+  const vpY = viewport.y * scaleY;
+  const vpW = Math.max(4, Math.min(mmW - 1, viewport.w * scaleX));
+  const vpH = Math.max(4, Math.min(mmH - 1, viewport.h * scaleY));
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        bottom: PAD,
+        right: PAD,
+        zIndex: 50,
+        background: 'rgba(13, 13, 26, 0.92)',
+        border: '1px solid #333366',
+        borderRadius: 6,
+        padding: 6,
+        pointerEvents: 'auto',
+        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.5)',
+      }}
+      title="Workspace overview — click or drag to jump"
+    >
+      <svg
+        ref={svgRef}
+        width={mmW}
+        height={mmH}
+        onMouseDown={handleMouseDown}
+        style={{ display: 'block', cursor: 'pointer', background: '#0a0a18', borderRadius: 3 }}
+      >
+        {sessions.map(s => {
+          const x = (s.col * tileWidth + (s.col + 1) * gap) * scaleX;
+          const y = (s.row * tileHeight + (s.row + 1) * gap) * scaleY;
+          const w = Math.max(2, tileWidth * scaleX);
+          const h = Math.max(2, tileHeight * scaleY);
+          const fill = s.state === 'connected' ? '#4aaa6a'
+            : s.state === 'connecting' ? '#caaa4a'
+            : s.state === 'error' ? '#ff5555'
+            : '#555';
+          return (
+            <rect key={s.id} x={x} y={y} width={w} height={h} fill={fill} opacity={0.65} rx={1} />
+          );
+        })}
+        <rect
+          x={vpX}
+          y={vpY}
+          width={vpW}
+          height={vpH}
+          fill="rgba(124, 106, 247, 0.15)"
+          stroke="#7c6af7"
+          strokeWidth={1.5}
+          pointerEvents="none"
+        />
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a small SVG minimap in the bottom-right of the terminal workspace.
- Shows every tile as a scaled rectangle (colored by connection state) and outlines the current viewport.
- Click anywhere on the minimap to jump; drag for continuous scrolling.
- Auto-hides when the grid already fits on screen — no extra chrome for small workspaces.
- Frontend-only; no backend changes, no new dependencies.

## How it works
- `WorkspaceMinimap.tsx` receives the outer scroll container via ref, subscribes to `scroll` + `ResizeObserver` to track viewport position and size.
- Renders tiles by mapping grid coordinates through a scale factor `mmWidth / gridWidth`.
- Click handler converts minimap-pixel coords back to grid-pixel coords and calls `scrollTo({ left, top, behavior: 'smooth' })`, centering on the click.
- Visibility toggled by comparing `scrollWidth/Height` vs `clientWidth/Height` on the outer container.

## Interactions
- **Click**: center viewport on that spot.
- **Click + drag**: pan continuously as you move.
- **Tile colors**: green = connected, yellow = connecting, red = error, grey = disconnected.
- **Purple outline**: current viewport rectangle.

## Test plan
- [x] `make test` — backend 174, frontend 129, e2e 7 (all green)
- [x] TypeScript strict check passes
- [ ] Manual: add enough tiles so the grid scrolls; confirm minimap appears
- [ ] Manual: click the minimap, verify viewport jumps
- [ ] Manual: drag in minimap, verify smooth panning
- [ ] Manual: shrink tile count so everything fits; confirm minimap hides