### PR TITLE
feat: add terminal grid limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,17 @@ app:
     cols: 80            # terminal width in characters
     rows: 24            # terminal height in characters
     font_size: 14       # font size in pixels
+  terminal_grid:
+    max_cols: null      # null, 0, or omitted = unlimited
+    max_rows: null      # null, 0, or omitted = unlimited
   transport:
     prefer_mosh: false
     ssh_fallback: true
 ```
 
 The `default_term` settings control the size of every terminal tile. Each tile is rendered at a fixed pixel size derived from `cols`, `rows`, and `font_size`. When tiles exceed the browser viewport, the workspace scrolls horizontally and vertically. All three values can also be adjusted live from the top bar — changes are saved back to `app.yaml` automatically.
+
+The optional `terminal_grid` settings cap the number of columns and rows available in the terminals workspace. By default both directions are unlimited. `WEBMUX_TERMINAL_GRID_MAX_COLS` and `WEBMUX_TERMINAL_GRID_MAX_ROWS` override the YAML values at runtime; set either variable to a positive integer, or to `0`/`unlimited` for no limit.
 
 ### `auth.yaml` — Authentication
 

--- a/docs/webmux.1
+++ b/docs/webmux.1
@@ -84,6 +84,19 @@ Default terminal dimensions and font size for new sessions.
 Users can adjust these at runtime from the top bar; changes are
 persisted back to this file.
 .TP
+.B app.terminal_grid.max_cols / .max_rows
+Optional maximum column and row count for the terminals workspace.
+Unset,
+.BR null ,
+or
+.B 0
+means unlimited.
+The environment variables
+.B WEBMUX_TERMINAL_GRID_MAX_COLS
+and
+.B WEBMUX_TERMINAL_GRID_MAX_ROWS
+override these values at runtime.
+.TP
 .B app.transport.prefer_mosh
 When
 .BR true ,

--- a/tests/backend/apiRoutes.test.ts
+++ b/tests/backend/apiRoutes.test.ts
@@ -180,6 +180,25 @@ describe('API Routes', () => {
       expect(res.status).toBe(200);
       expect(res.body.app.name).toBe('webmux');
     });
+
+    it('returns environment-overridden terminal grid limits', async () => {
+      const originalMaxCols = process.env.WEBMUX_TERMINAL_GRID_MAX_COLS;
+      const originalMaxRows = process.env.WEBMUX_TERMINAL_GRID_MAX_ROWS;
+      process.env.WEBMUX_TERMINAL_GRID_MAX_COLS = '2';
+      process.env.WEBMUX_TERMINAL_GRID_MAX_ROWS = '3';
+
+      try {
+        const res = await request(app).get('/api/config');
+        expect(res.status).toBe(200);
+        expect(res.body.app.terminal_grid.max_cols).toBe(2);
+        expect(res.body.app.terminal_grid.max_rows).toBe(3);
+      } finally {
+        if (originalMaxCols === undefined) delete process.env.WEBMUX_TERMINAL_GRID_MAX_COLS;
+        else process.env.WEBMUX_TERMINAL_GRID_MAX_COLS = originalMaxCols;
+        if (originalMaxRows === undefined) delete process.env.WEBMUX_TERMINAL_GRID_MAX_ROWS;
+        else process.env.WEBMUX_TERMINAL_GRID_MAX_ROWS = originalMaxRows;
+      }
+    });
   });
 
   describe('PUT /api/config', () => {
@@ -189,6 +208,15 @@ describe('API Routes', () => {
         .send({ app: { name: 'updated' } });
       expect(res.status).toBe(200);
       expect(res.body.app.name).toBe('updated');
+    });
+
+    it('updates terminal grid limits', async () => {
+      const res = await request(app)
+        .put('/api/config')
+        .send({ app: { terminal_grid: { max_cols: 4, max_rows: 3 } } });
+      expect(res.status).toBe(200);
+      expect(res.body.app.terminal_grid.max_cols).toBe(4);
+      expect(res.body.app.terminal_grid.max_rows).toBe(3);
     });
   });
 
@@ -225,6 +253,19 @@ describe('API Routes', () => {
         .post('/api/sessions')
         .send({ hostname: 'box.example.com' });
       expect(res.status).toBe(400);
+    });
+
+    it('returns 400 when requested terminal position exceeds grid limits', async () => {
+      await request(app)
+        .put('/api/config')
+        .send({ app: { terminal_grid: { max_cols: 1, max_rows: 1 } } });
+
+      const res = await request(app)
+        .post('/api/sessions')
+        .send({ username: 'user', hostname: 'box.example.com', row: 0, col: 1 });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain('exceeds max_cols 1');
     });
   });
 

--- a/tests/backend/sessionBroker.test.ts
+++ b/tests/backend/sessionBroker.test.ts
@@ -100,6 +100,43 @@ describe('SessionBroker', () => {
     expect(s2.col).toBe(1);
   });
 
+  it('wraps automatic terminal positions when max_cols is set', async () => {
+    const configDir = path.join(tmpDir, 'config');
+    fs.writeFileSync(path.join(configDir, 'app.yaml'), 'app:\n  name: webmux\n  listen_host: 0.0.0.0\n  http_port: 8080\n  https_port: 8443\n  secure_mode: false\n  trusted_http_allowed: true\n  default_term:\n    cols: 80\n    rows: 24\n    font_size: 14\n  terminal_grid:\n    max_cols: 1\n    max_rows: 2\n  transport:\n    prefer_mosh: false\n    ssh_fallback: true\n');
+
+    const broker = new SessionBroker();
+    await broker.initialize();
+    const s1 = await broker.create({ username: 'u', hostname: 'h' });
+    const s2 = await broker.create({ username: 'u', hostname: 'h' });
+
+    expect(s1.row).toBe(0);
+    expect(s1.col).toBe(0);
+    expect(s2.row).toBe(1);
+    expect(s2.col).toBe(0);
+  });
+
+  it('rejects terminal sessions when the configured grid is full', async () => {
+    const configDir = path.join(tmpDir, 'config');
+    fs.writeFileSync(path.join(configDir, 'app.yaml'), 'app:\n  name: webmux\n  listen_host: 0.0.0.0\n  http_port: 8080\n  https_port: 8443\n  secure_mode: false\n  trusted_http_allowed: true\n  default_term:\n    cols: 80\n    rows: 24\n    font_size: 14\n  terminal_grid:\n    max_cols: 1\n    max_rows: 1\n  transport:\n    prefer_mosh: false\n    ssh_fallback: true\n');
+
+    const broker = new SessionBroker();
+    await broker.initialize();
+    await broker.create({ username: 'u', hostname: 'h' });
+
+    await expect(broker.create({ username: 'u', hostname: 'h' })).rejects.toThrow('Terminal grid is full');
+  });
+
+  it('rejects moves outside the configured terminal grid', async () => {
+    const configDir = path.join(tmpDir, 'config');
+    fs.writeFileSync(path.join(configDir, 'app.yaml'), 'app:\n  name: webmux\n  listen_host: 0.0.0.0\n  http_port: 8080\n  https_port: 8443\n  secure_mode: false\n  trusted_http_allowed: true\n  default_term:\n    cols: 80\n    rows: 24\n    font_size: 14\n  terminal_grid:\n    max_cols: 1\n    max_rows: 1\n  transport:\n    prefer_mosh: false\n    ssh_fallback: true\n');
+
+    const broker = new SessionBroker();
+    await broker.initialize();
+    const session = await broker.create({ username: 'u', hostname: 'h' });
+
+    expect(() => broker.move(session.id, 0, 1)).toThrow('exceeds max_cols 1');
+  });
+
   it('persists sessions to disk', async () => {
     const broker = new SessionBroker();
     await broker.initialize();

--- a/tests/frontend/App.test.tsx
+++ b/tests/frontend/App.test.tsx
@@ -48,10 +48,45 @@ vi.mock('@frontend/components/GraphicsWorkspace', () => ({
 }));
 
 import App from '@frontend/App';
+import { api } from '@frontend/utils/api';
+
+const defaultConfig = {
+  app: {
+    name: 'webmux',
+    http_port: 8080,
+    https_port: 8443,
+    secure_mode: false,
+    trusted_http_allowed: true,
+    default_term: { cols: 80, rows: 24, font_size: 14 },
+    terminal_grid: { max_cols: null, max_rows: null },
+  },
+};
+
+const mockSession = {
+  id: 's1',
+  owner: 'u1',
+  transport: 'ssh' as const,
+  host_id: '',
+  hostname: 'h1',
+  username: 'u1',
+  key_id: '',
+  cols: 80,
+  rows: 24,
+  row: 0,
+  col: 0,
+  port: 22,
+  state: 'connected' as const,
+  created_at: '',
+  updated_at: '',
+  title: 'u1@h1',
+  persistent: true,
+};
 
 describe('App', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    (api.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(defaultConfig);
+    (api.getSessions as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     mockAuth.isAuthenticated = false;
     mockAuth.isLoading = true;
     mockAuth.authStatus = null;
@@ -61,7 +96,7 @@ describe('App', () => {
   it('shows loading state', async () => {
     render(<App />);
     expect(screen.getByText('Loading...')).toBeDefined();
-    // Let the useEffect (api.getConfig) settle to avoid act() warnings
+    // Let pending effects settle to avoid act() warnings.
     await act(async () => {});
   });
 
@@ -71,7 +106,7 @@ describe('App', () => {
     render(<App />);
     expect(screen.getByText('WebMux')).toBeDefined();
     expect(screen.getByRole('button', { name: /sign in/i })).toBeDefined();
-    // Let the useEffect (api.getConfig) settle to avoid act() warnings
+    // Let pending effects settle to avoid act() warnings.
     await act(async () => {});
   });
 
@@ -82,6 +117,37 @@ describe('App', () => {
     render(<App />);
     await waitFor(() => {
       expect(screen.getByText('Click to add a session')).toBeDefined();
+    });
+  });
+
+  it('loads config after authentication and applies terminal grid limits', async () => {
+    mockAuth.isLoading = false;
+    mockAuth.isAuthenticated = false;
+    mockAuth.authStatus = { mode: 'local', bootstrap_required: false };
+    (api.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue({
+      app: {
+        ...defaultConfig.app,
+        terminal_grid: { max_cols: null, max_rows: 1 },
+      },
+    });
+    (api.getSessions as ReturnType<typeof vi.fn>).mockResolvedValue([mockSession]);
+
+    const { rerender } = render(<App />);
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeDefined();
+    expect(api.getConfig).not.toHaveBeenCalled();
+
+    mockAuth.isAuthenticated = true;
+    await act(async () => {
+      rerender(<App />);
+    });
+
+    await waitFor(() => {
+      expect(api.getConfig).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('u1@h1')).toBeDefined();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('add-cell-0-1')).toBeDefined();
+      expect(screen.queryByTestId('add-cell-1-0')).toBeNull();
     });
   });
 });

--- a/tests/frontend/Workspace.test.tsx
+++ b/tests/frontend/Workspace.test.tsx
@@ -79,6 +79,18 @@ describe('Workspace', () => {
     });
   });
 
+  it('hides add cells outside the terminal grid limit', async () => {
+    const { api } = await import('@frontend/utils/api');
+    (api.getSessions as ReturnType<typeof vi.fn>).mockResolvedValue(mockSessions);
+
+    render(<Workspace {...defaultProps} terminalGridLimit={{ maxCols: 1, maxRows: 1 }} />, { wrapper });
+    await waitFor(() => {
+      expect(screen.getByText('u1@h1')).toBeDefined();
+    });
+    expect(screen.queryByTestId('add-cell-0-1')).toBeNull();
+    expect(screen.queryByTestId('add-cell-1-0')).toBeNull();
+  });
+
   it('opens connection dialog when add cell clicked', async () => {
     const { api } = await import('@frontend/utils/api');
     (api.getSessions as ReturnType<typeof vi.fn>).mockResolvedValue([]);

--- a/webmux/README.md
+++ b/webmux/README.md
@@ -48,7 +48,12 @@ app:
     cols: 80
     rows: 24
     font_size: 14
+  terminal_grid:
+    max_cols: null      # null, 0, or omitted = unlimited
+    max_rows: null      # null, 0, or omitted = unlimited
 ```
+
+`WEBMUX_TERMINAL_GRID_MAX_COLS` and `WEBMUX_TERMINAL_GRID_MAX_ROWS` can override those YAML values at runtime.
 
 Add hosts to `config/hosts.yaml`:
 

--- a/webmux/backend/src/api/config.ts
+++ b/webmux/backend/src/api/config.ts
@@ -2,13 +2,18 @@ import { Router, Request, Response } from 'express';
 import { persistence } from '../services/persistenceManager';
 import { requireAuth } from '../middleware/auth';
 import { TransportLauncher } from '../services/transportLauncher';
+import {
+  appConfigWithEffectiveTerminalGridLimits,
+  isTerminalGridLimitError,
+  terminalGridLimitsFromApp,
+} from '../services/terminalGridLimits';
 
 const router = Router();
 router.use(requireAuth);
 
 router.get('/', (_req: Request, res: Response) => {
   try {
-    const app = persistence.loadApp();
+    const app = appConfigWithEffectiveTerminalGridLimits(persistence.loadApp());
     const execCommand = process.env.WEBMUX_EXEC_COMMAND;
     if (execCommand) {
       app.app.exec_command = execCommand;
@@ -20,7 +25,7 @@ router.get('/', (_req: Request, res: Response) => {
 });
 
 // Only allow updating safe fields — not listen_host, ports, or secure_mode at runtime
-const MUTABLE_APP_FIELDS = ['name', 'default_term', 'transport'];
+const MUTABLE_APP_FIELDS = ['name', 'default_term', 'terminal_grid', 'transport'];
 
 router.put('/', (req: Request, res: Response) => {
   try {
@@ -45,8 +50,17 @@ router.put('/', (req: Request, res: Response) => {
       }
     }
     const merged = { app: { ...current.app, ...updates } };
+    try {
+      terminalGridLimitsFromApp(merged);
+    } catch (err) {
+      if (isTerminalGridLimitError(err)) {
+        res.status(400).json({ error: (err as Error).message });
+        return;
+      }
+      throw err;
+    }
     persistence.saveApp(merged);
-    res.json(merged);
+    res.json(appConfigWithEffectiveTerminalGridLimits(merged));
   } catch {
     res.status(500).json({ error: 'Failed to save config' });
   }

--- a/webmux/backend/src/api/sessions.ts
+++ b/webmux/backend/src/api/sessions.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from 'express';
 import { sessionBroker } from '../services/sessionBroker';
 import { requireAuth, AuthPayload } from '../middleware/auth';
 import { CreateSessionRequest } from '../types';
+import { isTerminalGridLimitError } from '../services/terminalGridLimits';
 
 const router = Router();
 router.use(requireAuth);
@@ -36,6 +37,10 @@ router.post('/', async (req: Request, res: Response) => {
     const session = await sessionBroker.create(body, owner);
     res.status(201).json(session);
   } catch (err) {
+    if (isTerminalGridLimitError(err)) {
+      res.status(400).json({ error: (err as Error).message });
+      return;
+    }
     console.error('Create session error:', err);
     res.status(500).json({ error: 'Failed to create session' });
   }
@@ -82,8 +87,16 @@ router.patch('/:id', (req: Request, res: Response) => {
     res.status(400).json({ error: 'row and col are required' });
     return;
   }
-  const updated = sessionBroker.move(req.params.id, row, col);
-  res.json(updated);
+  try {
+    const updated = sessionBroker.move(req.params.id, row, col);
+    res.json(updated);
+  } catch (err) {
+    if (isTerminalGridLimitError(err)) {
+      res.status(400).json({ error: (err as Error).message });
+      return;
+    }
+    throw err;
+  }
 });
 
 router.delete('/:id', async (req: Request, res: Response) => {

--- a/webmux/backend/src/index.ts
+++ b/webmux/backend/src/index.ts
@@ -42,6 +42,7 @@ async function main(): Promise<void> {
         secure_mode: false,
         trusted_http_allowed: true,
         default_term: { cols: 80, rows: 24, font_size: 14 },
+        terminal_grid: { max_cols: null, max_rows: null },
         transport: { prefer_mosh: false, ssh_fallback: true, mosh_server_path: '' },
       },
     };

--- a/webmux/backend/src/services/sessionBroker.ts
+++ b/webmux/backend/src/services/sessionBroker.ts
@@ -5,7 +5,8 @@ import { Session, CreateSessionRequest } from '../types';
 import { transportLauncher } from './transportLauncher';
 import { presenceService } from './presenceService';
 import { persistence } from './persistenceManager';
-import { nextPositionFor, compactPositions } from './gridLayout';
+import { compactPositions } from './gridLayout';
+import { assertTerminalGridPosition, nextTerminalGridPosition } from './terminalGridLimits';
 
 export class SessionBroker extends EventEmitter {
   private sessions = new Map<string, Session>();
@@ -78,7 +79,7 @@ export class SessionBroker extends EventEmitter {
 
     // Determine layout position (scoped to this owner's sessions)
     const ownerSessions = Array.from(this.sessions.values()).filter(s => s.owner === owner);
-    const { row, col } = nextPositionFor(ownerSessions, req.row, req.col);
+    const { row, col } = nextTerminalGridPosition(ownerSessions, req.row, req.col);
 
     // Determine transport: use mosh if host allows it and config prefers it
     let transport = req.transport || 'ssh';
@@ -138,7 +139,7 @@ export class SessionBroker extends EventEmitter {
     }
 
     this.persistSessions();
-    persistence.appendEvent({ type: 'session_created', session_id: id, hostname, username: req.username });
+    await persistence.appendEvent({ type: 'session_created', session_id: id, hostname, username: req.username });
     this.emit('session_created', session);
     return session;
   }
@@ -243,7 +244,7 @@ export class SessionBroker extends EventEmitter {
     }
     this.persistSessions();
     this.updateLayout(sessionId);
-    persistence.appendEvent({ type: 'session_deleted', session_id: sessionId });
+    await persistence.appendEvent({ type: 'session_deleted', session_id: sessionId });
     this.emit('session_deleted', sessionId);
   }
 
@@ -262,6 +263,7 @@ export class SessionBroker extends EventEmitter {
   move(sessionId: string, row: number, col: number): Session {
     const session = this.sessions.get(sessionId);
     if (!session) throw new Error(`Session ${sessionId} not found`);
+    assertTerminalGridPosition(row, col);
     session.row = row;
     session.col = col;
     session.updated_at = new Date().toISOString();

--- a/webmux/backend/src/services/terminalGridLimits.ts
+++ b/webmux/backend/src/services/terminalGridLimits.ts
@@ -1,0 +1,160 @@
+import { AppConfig } from '../types';
+import { GridItem, nextPositionFor } from './gridLayout';
+import { persistence } from './persistenceManager';
+
+export interface TerminalGridLimits {
+  maxCols?: number;
+  maxRows?: number;
+}
+
+export class TerminalGridLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'TerminalGridLimitError';
+  }
+}
+
+type RawGridLimit = number | string | null | undefined;
+
+const MAX_COLS_ENV = 'WEBMUX_TERMINAL_GRID_MAX_COLS';
+const MAX_ROWS_ENV = 'WEBMUX_TERMINAL_GRID_MAX_ROWS';
+
+function normalizeGridLimit(value: RawGridLimit, label: string): number | undefined {
+  if (value === undefined || value === null) return undefined;
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim().toLowerCase();
+    if (!trimmed || trimmed === '0' || trimmed === 'none' || trimmed === 'unlimited' || trimmed === 'infinite') {
+      return undefined;
+    }
+    const parsed = Number(trimmed);
+    if (Number.isInteger(parsed) && parsed > 0) return parsed;
+  } else if (Number.isInteger(value)) {
+    if (value === 0) return undefined;
+    if (value > 0) return value;
+  }
+
+  throw new TerminalGridLimitError(`${label} must be a positive integer, null, 0, or unlimited`);
+}
+
+function envGridLimit(name: string, label: string): { present: boolean; value?: number } {
+  if (!(name in process.env)) return { present: false };
+  return { present: true, value: normalizeGridLimit(process.env[name], label) };
+}
+
+export function terminalGridLimitsFromApp(config: AppConfig): TerminalGridLimits {
+  return {
+    maxCols: normalizeGridLimit(config.app.terminal_grid?.max_cols, 'app.terminal_grid.max_cols'),
+    maxRows: normalizeGridLimit(config.app.terminal_grid?.max_rows, 'app.terminal_grid.max_rows'),
+  };
+}
+
+export function effectiveTerminalGridLimits(config: AppConfig): TerminalGridLimits {
+  const configured = terminalGridLimitsFromApp(config);
+  const envMaxCols = envGridLimit(MAX_COLS_ENV, MAX_COLS_ENV);
+  const envMaxRows = envGridLimit(MAX_ROWS_ENV, MAX_ROWS_ENV);
+
+  return {
+    maxCols: envMaxCols.present ? envMaxCols.value : configured.maxCols,
+    maxRows: envMaxRows.present ? envMaxRows.value : configured.maxRows,
+  };
+}
+
+export function appConfigWithEffectiveTerminalGridLimits(config: AppConfig): AppConfig {
+  const limits = effectiveTerminalGridLimits(config);
+  return {
+    app: {
+      ...config.app,
+      terminal_grid: {
+        ...config.app.terminal_grid,
+        max_cols: limits.maxCols ?? null,
+        max_rows: limits.maxRows ?? null,
+      },
+    },
+  };
+}
+
+export function loadTerminalGridLimits(): TerminalGridLimits {
+  try {
+    return effectiveTerminalGridLimits(persistence.loadApp());
+  } catch (err) {
+    if (err instanceof TerminalGridLimitError) throw err;
+    const envMaxCols = envGridLimit(MAX_COLS_ENV, MAX_COLS_ENV);
+    const envMaxRows = envGridLimit(MAX_ROWS_ENV, MAX_ROWS_ENV);
+    return {
+      maxCols: envMaxCols.present ? envMaxCols.value : undefined,
+      maxRows: envMaxRows.present ? envMaxRows.value : undefined,
+    };
+  }
+}
+
+export function isTerminalGridLimitError(err: unknown): err is TerminalGridLimitError {
+  return err instanceof TerminalGridLimitError;
+}
+
+export function assertTerminalGridPosition(
+  row: number,
+  col: number,
+  limits: TerminalGridLimits = loadTerminalGridLimits(),
+): void {
+  if (!Number.isInteger(row) || !Number.isInteger(col) || row < 0 || col < 0) {
+    throw new TerminalGridLimitError('Terminal grid row and col must be non-negative integers');
+  }
+
+  if (limits.maxRows !== undefined && row >= limits.maxRows) {
+    throw new TerminalGridLimitError(`Terminal grid row ${row} exceeds max_rows ${limits.maxRows}`);
+  }
+
+  if (limits.maxCols !== undefined && col >= limits.maxCols) {
+    throw new TerminalGridLimitError(`Terminal grid column ${col} exceeds max_cols ${limits.maxCols}`);
+  }
+}
+
+export function nextTerminalGridPosition(
+  items: GridItem[],
+  requestedRow?: number,
+  requestedCol?: number,
+  limits: TerminalGridLimits = loadTerminalGridLimits(),
+): { row: number; col: number } {
+  if (requestedRow !== undefined && requestedCol !== undefined) {
+    assertTerminalGridPosition(requestedRow, requestedCol, limits);
+    return { row: requestedRow, col: requestedCol };
+  }
+
+  if (limits.maxCols === undefined && limits.maxRows === undefined) {
+    return nextPositionFor(items);
+  }
+
+  if (items.length === 0) {
+    assertTerminalGridPosition(0, 0, limits);
+    return { row: 0, col: 0 };
+  }
+
+  const occupied = new Set(items.map(item => `${item.row},${item.col}`));
+
+  if (limits.maxCols !== undefined) {
+    const maxExistingRow = Math.max(...items.map(item => item.row));
+    const rowSearchLimit = limits.maxRows ?? maxExistingRow + 2;
+
+    for (let row = 0; row < rowSearchLimit; row++) {
+      for (let col = 0; col < limits.maxCols; col++) {
+        if (!occupied.has(`${row},${col}`)) return { row, col };
+      }
+    }
+
+    throw new TerminalGridLimitError('Terminal grid is full');
+  }
+
+  const inBoundsItems = items.filter(item => limits.maxRows === undefined || item.row < limits.maxRows);
+  if (inBoundsItems.length === 0) {
+    assertTerminalGridPosition(0, 0, limits);
+    return { row: 0, col: 0 };
+  }
+
+  const maxRow = Math.max(...inBoundsItems.map(item => item.row));
+  const rowItems = inBoundsItems.filter(item => item.row === maxRow);
+  const maxCol = Math.max(...rowItems.map(item => item.col));
+  const candidate = { row: maxRow, col: maxCol + 1 };
+  assertTerminalGridPosition(candidate.row, candidate.col, limits);
+  return candidate;
+}

--- a/webmux/backend/src/types/index.ts
+++ b/webmux/backend/src/types/index.ts
@@ -11,6 +11,10 @@ export interface AppConfig {
       rows: number;
       font_size: number;
     };
+    terminal_grid?: {
+      max_cols?: number | null;
+      max_rows?: number | null;
+    };
     transport: {
       prefer_mosh: boolean;
       ssh_fallback: boolean;
@@ -212,4 +216,3 @@ export interface CreateRdpSessionRequest {
   row?: number;
   col?: number;
 }
-

--- a/webmux/config.defaults/app.yaml
+++ b/webmux/config.defaults/app.yaml
@@ -9,6 +9,9 @@ app:
     cols: 80
     rows: 24
     font_size: 14
+  terminal_grid:
+    max_cols: null
+    max_rows: null
   transport:
     prefer_mosh: false
     ssh_fallback: true

--- a/webmux/frontend/src/App.tsx
+++ b/webmux/frontend/src/App.tsx
@@ -17,6 +17,10 @@ interface AuthenticatedAppProps {
   termCols: number;
   termRows: number;
   onTermSizeChange: (cols: number, rows: number) => void;
+  terminalGridLimit: {
+    maxCols: number | null;
+    maxRows: number | null;
+  };
   onNewAccount: () => void;
   secureMode: boolean;
   currentUser: string | null;
@@ -32,6 +36,7 @@ function AuthenticatedApp({
   termCols,
   termRows,
   onTermSizeChange,
+  terminalGridLimit,
   onNewAccount,
   secureMode,
   currentUser,
@@ -57,7 +62,7 @@ function AuthenticatedApp({
 
       <div style={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
         <div style={{ display: activePane === 'terminals' ? 'flex' : 'none', height: '100%', flexDirection: 'column' }}>
-          <Workspace fontSize={fontSize} termCols={termCols} termRows={termRows} />
+          <Workspace fontSize={fontSize} termCols={termCols} termRows={termRows} terminalGridLimit={terminalGridLimit} />
         </div>
         <div style={{ display: activePane === 'desktops' ? 'flex' : 'none', height: '100%', flexDirection: 'column' }}>
           <GraphicsWorkspace />
@@ -94,6 +99,10 @@ export default function App() {
   const [fontSize, setFontSize] = useState(14);
   const [termCols, setTermCols] = useState(80);
   const [termRows, setTermRows] = useState(24);
+  const [terminalGridLimit, setTerminalGridLimit] = useState<{ maxCols: number | null; maxRows: number | null }>({
+    maxCols: null,
+    maxRows: null,
+  });
   const [showRegister, setShowRegister] = useState(false);
   const [secureMode, setSecureMode] = useState(true);
 
@@ -105,6 +114,10 @@ export default function App() {
       setFontSize(config.app.default_term.font_size);
       setTermCols(config.app.default_term.cols);
       setTermRows(config.app.default_term.rows);
+      setTerminalGridLimit({
+        maxCols: config.app.terminal_grid?.max_cols ?? null,
+        maxRows: config.app.terminal_grid?.max_rows ?? null,
+      });
     }).catch(() => {});
   }, []);
 
@@ -146,6 +159,7 @@ export default function App() {
           termCols={termCols}
           termRows={termRows}
           onTermSizeChange={handleTermSizeChange}
+          terminalGridLimit={terminalGridLimit}
           onNewAccount={() => setShowRegister(true)}
           secureMode={secureMode}
           currentUser={currentUser}

--- a/webmux/frontend/src/App.tsx
+++ b/webmux/frontend/src/App.tsx
@@ -109,7 +109,11 @@ export default function App() {
   const currentUser = useMemo(() => auth.isAuthenticated ? parseTokenUser() : null, [auth.isAuthenticated]);
 
   useEffect(() => {
+    if (auth.isLoading || !auth.isAuthenticated) return;
+
+    let cancelled = false;
     api.getConfig().then(config => {
+      if (cancelled) return;
       setSecureMode(config.app.secure_mode);
       setFontSize(config.app.default_term.font_size);
       setTermCols(config.app.default_term.cols);
@@ -119,7 +123,8 @@ export default function App() {
         maxRows: config.app.terminal_grid?.max_rows ?? null,
       });
     }).catch(() => {});
-  }, []);
+    return () => { cancelled = true; };
+  }, [auth.isAuthenticated, auth.isLoading]);
 
   const handleFontSizeChange = useCallback((size: number) => {
     setFontSize(size);

--- a/webmux/frontend/src/components/Workspace.tsx
+++ b/webmux/frontend/src/components/Workspace.tsx
@@ -8,6 +8,10 @@ interface WorkspaceProps {
   fontSize: number;
   termCols: number;
   termRows: number;
+  terminalGridLimit?: {
+    maxCols?: number | null;
+    maxRows?: number | null;
+  };
 }
 
 const GAP = 8;
@@ -22,8 +26,28 @@ function tilePixelSize(cols: number, rows: number, fontSize: number) {
   return { w, h };
 }
 
-function getAddPositions(sessions: Session[]): { row: number; col: number }[] {
-  if (sessions.length === 0) return [{ row: 0, col: 0 }];
+function normalizedLimit(value?: number | null): number | undefined {
+  if (typeof value !== 'number') return undefined;
+  return Number.isInteger(value) && value > 0 ? value : undefined;
+}
+
+function isWithinTerminalGridLimit(
+  row: number,
+  col: number,
+  terminalGridLimit?: WorkspaceProps['terminalGridLimit'],
+): boolean {
+  const maxCols = normalizedLimit(terminalGridLimit?.maxCols);
+  const maxRows = normalizedLimit(terminalGridLimit?.maxRows);
+  return (maxCols === undefined || col < maxCols) && (maxRows === undefined || row < maxRows);
+}
+
+function getAddPositions(
+  sessions: Session[],
+  terminalGridLimit?: WorkspaceProps['terminalGridLimit'],
+): { row: number; col: number }[] {
+  if (sessions.length === 0) {
+    return isWithinTerminalGridLimit(0, 0, terminalGridLimit) ? [{ row: 0, col: 0 }] : [];
+  }
 
   const occupied = new Set(sessions.map(s => `${s.row},${s.col}`));
   const positions: { row: number; col: number }[] = [];
@@ -31,12 +55,12 @@ function getAddPositions(sessions: Session[]): { row: number; col: number }[] {
 
   for (const s of sessions) {
     const right = `${s.row},${s.col + 1}`;
-    if (!occupied.has(right) && !seen.has(right)) {
+    if (!occupied.has(right) && !seen.has(right) && isWithinTerminalGridLimit(s.row, s.col + 1, terminalGridLimit)) {
       positions.push({ row: s.row, col: s.col + 1 });
       seen.add(right);
     }
     const below = `${s.row + 1},${s.col}`;
-    if (!occupied.has(below) && !seen.has(below)) {
+    if (!occupied.has(below) && !seen.has(below) && isWithinTerminalGridLimit(s.row + 1, s.col, terminalGridLimit)) {
       positions.push({ row: s.row + 1, col: s.col });
       seen.add(below);
     }
@@ -95,11 +119,10 @@ function AddCell({ row, col, isEmpty, onClick }: {
   );
 }
 
-export function Workspace({ fontSize, termCols, termRows }: WorkspaceProps) {
+export function Workspace({ fontSize, termCols, termRows, terminalGridLimit }: WorkspaceProps) {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
   const [dialogPos, setDialogPos] = useState<{ row: number; col: number } | null>(null);
-
 
   // Drag state
   const [draggingId, setDraggingId] = useState<string | null>(null);
@@ -179,7 +202,7 @@ export function Workspace({ fontSize, termCols, termRows }: WorkspaceProps) {
     const onMouseMove = (e: MouseEvent) => {
       setGhostPos({ x: e.clientX, y: e.clientY });
       const cell = getGridCell(e.clientX, e.clientY);
-      if (cell) {
+      if (cell && isWithinTerminalGridLimit(cell.row, cell.col, terminalGridLimit)) {
         const sessionAtCell = sessionsRef.current.find(s => s.row === cell.row && s.col === cell.col);
         const isSelf = sessionAtCell && sessionAtCell.id === draggingIdRef.current;
         const newTarget = isSelf ? null : cell;
@@ -241,9 +264,9 @@ export function Workspace({ fontSize, termCols, termRows }: WorkspaceProps) {
       document.removeEventListener('mousemove', onMouseMove);
       document.removeEventListener('mouseup', onMouseUp);
     };
-  }, [draggingId, getGridCell]);
+  }, [draggingId, getGridCell, terminalGridLimit]);
 
-  const addPositions = getAddPositions(sessions);
+  const addPositions = getAddPositions(sessions, terminalGridLimit);
 
   const allPositions = [
     ...sessions.map(s => ({ row: s.row, col: s.col })),

--- a/webmux/frontend/src/types/index.ts
+++ b/webmux/frontend/src/types/index.ts
@@ -93,6 +93,10 @@ export interface AppConfig {
       rows: number;
       font_size: number;
     };
+    terminal_grid?: {
+      max_cols?: number | null;
+      max_rows?: number | null;
+    };
     // Set by WEBMUX_EXEC_COMMAND on the server; drives exec-transport defaults in the UI.
     exec_command?: string;
   };


### PR DESCRIPTION
## Summary
- Add configurable terminal grid row/column limits for session placement.
- Enforce limits in backend session create/move paths and expose effective limits through config.
- Apply limits in the terminal workspace UI, including loading config only after auth succeeds so local-auth sessions receive the configured limits.
- Await session event writes so backend tests do not race temporary runtime directories.

## Testing
- `make test`