### PR TITLE
feat: add keyboard terminal cycling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A web-native terminal multiplexer — think tmux-on-a-jump-box, but it runs in y
 - **Multi-user accounts** — multiple users with separate session collections; Argon2id password hashing
 - **Multi-viewer presence** — multiple tabs can watch the same session; click-to-focus controls who has keyboard input
 - **Type to All** — broadcast mode sends keystrokes to every open session simultaneously
+- **Keyboard terminal cycling** — `Ctrl+Shift+<` and `Ctrl+Shift+>` focus previous/next terminal tiles
 - **SSH key and password auth** — managed keys via `keys.yaml`, password-based via `sshpass`
 - **Two security modes** — local auth (Argon2id + JWT + HTTPS) or trusted mode for isolated networks
 - **OS service integration** — `make install` sets up launchd (macOS) or systemd (Linux) for auto-start on boot

--- a/docs/webmux.1
+++ b/docs/webmux.1
@@ -194,6 +194,12 @@ scrolls the workspace view.
 .TP
 .B Wheel (over terminal, no modifier)
 Scrolls that terminal's scrollback buffer (5,000 lines).
+.TP
+.B Ctrl + Shift + < / >
+Focuses the previous or next terminal tile, ordered left to right and
+then top to bottom. Navigation wraps at either end and skips
+.B +
+placeholder cells.
 .SS Input broadcast
 The
 .B Type to All

--- a/tests/frontend/Workspace.test.tsx
+++ b/tests/frontend/Workspace.test.tsx
@@ -155,6 +155,16 @@ describe('Workspace', () => {
       await waitFor(() => {
         expect(terminalFocusFns.get('s3')).toHaveBeenCalledTimes(2);
       });
+
+      fireEvent.keyDown(window, { key: '>', ctrlKey: true, shiftKey: true });
+      await waitFor(() => {
+        expect(terminalFocusFns.get('s2')).toHaveBeenCalledTimes(3);
+      });
+
+      fireEvent.keyDown(window, { key: '<', ctrlKey: true, shiftKey: true });
+      await waitFor(() => {
+        expect(terminalFocusFns.get('s3')).toHaveBeenCalledTimes(3);
+      });
     } finally {
       if (originalOffsetParent) {
         Object.defineProperty(HTMLElement.prototype, 'offsetParent', originalOffsetParent);

--- a/tests/frontend/Workspace.test.tsx
+++ b/tests/frontend/Workspace.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { Workspace } from '@frontend/components/Workspace';
 import { InputBroadcastProvider } from '@frontend/contexts/InputBroadcastContext';
-import type { ReactNode } from 'react';
+import type { ReactNode, Ref } from 'react';
 
 const mockSessions = [
   {
@@ -11,6 +11,8 @@ const mockSessions = [
     state: 'connected' as const, created_at: '', updated_at: '', title: 'u1@h1', persistent: true,
   },
 ];
+
+const terminalFocusFns = vi.hoisted(() => new Map<string, ReturnType<typeof vi.fn>>());
 
 vi.mock('@frontend/utils/api', () => ({
   api: {
@@ -24,11 +26,25 @@ vi.mock('@frontend/utils/api', () => ({
   },
 }));
 
-vi.mock('@frontend/components/Terminal', () => ({
-  Terminal: vi.fn().mockImplementation(({ sessionId }: { sessionId: string }) => (
-    <div data-testid={`terminal-${sessionId}`}>Terminal Mock</div>
-  )),
-}));
+vi.mock('@frontend/components/Terminal', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  return {
+    Terminal: React.forwardRef(function TerminalMock(
+      { sessionId }: { sessionId: string },
+      ref: Ref<unknown>,
+    ) {
+      const focus = terminalFocusFns.get(sessionId) ?? vi.fn();
+      terminalFocusFns.set(sessionId, focus);
+      React.useImperativeHandle(ref, () => ({
+        scrollToBottom: vi.fn(),
+        isAtBottom: () => true,
+        sendInput: vi.fn(),
+        focus,
+      }));
+      return <div data-testid={`terminal-${sessionId}`}>Terminal Mock</div>;
+    }),
+  };
+});
 
 const wrapper = ({ children }: { children: ReactNode }) => (
   <InputBroadcastProvider>{children}</InputBroadcastProvider>
@@ -37,6 +53,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 describe('Workspace', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    terminalFocusFns.clear();
     const { api } = await import('@frontend/utils/api');
     (api.getSessions as ReturnType<typeof vi.fn>).mockResolvedValue([]);
   });
@@ -91,5 +108,59 @@ describe('Workspace', () => {
     await waitFor(() => {
       expect(screen.getByText('Connect to Host')).toBeDefined();
     });
+  });
+
+  it('cycles terminal focus left-to-right then down and wraps', async () => {
+    const { api } = await import('@frontend/utils/api');
+    const sessions = [
+      { ...mockSessions[0], id: 's1', title: 'one', row: 0, col: 1 },
+      { ...mockSessions[0], id: 's2', title: 'two', row: 0, col: 0 },
+      { ...mockSessions[0], id: 's3', title: 'three', row: 1, col: 0 },
+    ];
+    (api.getSessions as ReturnType<typeof vi.fn>).mockResolvedValue(sessions);
+
+    const originalOffsetParent = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetParent');
+    Object.defineProperty(HTMLElement.prototype, 'offsetParent', {
+      configurable: true,
+      get() { return document.body; },
+    });
+
+    try {
+      render(<Workspace {...defaultProps} />, { wrapper });
+      await waitFor(() => {
+        expect(screen.getByText('three')).toBeDefined();
+      });
+
+      fireEvent.keyDown(window, { code: 'Period', ctrlKey: true, shiftKey: true });
+      await waitFor(() => {
+        expect(terminalFocusFns.get('s2')).toHaveBeenCalledTimes(1);
+      });
+
+      fireEvent.keyDown(window, { code: 'Period', ctrlKey: true, shiftKey: true });
+      await waitFor(() => {
+        expect(terminalFocusFns.get('s1')).toHaveBeenCalledTimes(1);
+      });
+
+      fireEvent.keyDown(window, { code: 'Period', ctrlKey: true, shiftKey: true });
+      await waitFor(() => {
+        expect(terminalFocusFns.get('s3')).toHaveBeenCalledTimes(1);
+      });
+
+      fireEvent.keyDown(window, { code: 'Period', ctrlKey: true, shiftKey: true });
+      await waitFor(() => {
+        expect(terminalFocusFns.get('s2')).toHaveBeenCalledTimes(2);
+      });
+
+      fireEvent.keyDown(window, { code: 'Comma', ctrlKey: true, shiftKey: true });
+      await waitFor(() => {
+        expect(terminalFocusFns.get('s3')).toHaveBeenCalledTimes(2);
+      });
+    } finally {
+      if (originalOffsetParent) {
+        Object.defineProperty(HTMLElement.prototype, 'offsetParent', originalOffsetParent);
+      } else {
+        delete (HTMLElement.prototype as unknown as Record<string, unknown>).offsetParent;
+      }
+    }
   });
 });

--- a/webmux/README.md
+++ b/webmux/README.md
@@ -10,6 +10,7 @@ A web-native tmux-on-a-jump-box: a persistent shared terminal wall that runs in 
 - **Persistent sessions** — sessions survive browser tab closes; reconnect from any tab
 - **Multi-viewer** — multiple browser tabs can watch the same session; one has keyboard focus at a time
 - **Split right / split below** — tile your workspace like a tiling window manager
+- **Keyboard terminal cycling** — `Ctrl+Shift+<` and `Ctrl+Shift+>` focus previous/next terminal tiles
 - **Global font size** — resize all terminals at once
 - **Two auth modes**:
   - **Secure mode** — local login + HTTPS, Argon2id password hashing

--- a/webmux/backend/src/services/sessionBroker.ts
+++ b/webmux/backend/src/services/sessionBroker.ts
@@ -138,7 +138,7 @@ export class SessionBroker extends EventEmitter {
     }
 
     this.persistSessions();
-    persistence.appendEvent({ type: 'session_created', session_id: id, hostname, username: req.username });
+    await persistence.appendEvent({ type: 'session_created', session_id: id, hostname, username: req.username });
     this.emit('session_created', session);
     return session;
   }
@@ -243,7 +243,7 @@ export class SessionBroker extends EventEmitter {
     }
     this.persistSessions();
     this.updateLayout(sessionId);
-    persistence.appendEvent({ type: 'session_deleted', session_id: sessionId });
+    await persistence.appendEvent({ type: 'session_deleted', session_id: sessionId });
     this.emit('session_deleted', sessionId);
   }
 

--- a/webmux/frontend/src/components/HelpDialog.tsx
+++ b/webmux/frontend/src/components/HelpDialog.tsx
@@ -56,6 +56,8 @@ export function HelpDialog({ onClose }: HelpDialogProps) {
 
           <Section title="Keyboard Input">
             <Row label="Normal typing" desc="Input goes to the currently focused terminal tile." />
+            <Row label="Ctrl + Shift + <" desc="Focus the previous terminal tile." />
+            <Row label="Ctrl + Shift + >" desc="Focus the next terminal tile." />
             <Row label="Type to All" desc="When enabled (orange bar), every keystroke is sent to all open sessions simultaneously. Click the button again to disable." />
           </Section>
 

--- a/webmux/frontend/src/components/Terminal.tsx
+++ b/webmux/frontend/src/components/Terminal.tsx
@@ -11,6 +11,7 @@ export interface TerminalHandle {
   scrollToBottom: () => void;
   isAtBottom: () => boolean;
   sendInput: (data: string) => void;
+  focus: () => void;
 }
 
 interface TerminalProps {
@@ -46,6 +47,9 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     isAtBottom: () => !userScrolledRef.current,
     sendInput: (data: string) => {
       wsHandleRef.current?.send({ type: 'input', data });
+    },
+    focus: () => {
+      termRef.current?.focus();
     },
   }));
 

--- a/webmux/frontend/src/components/Tile.tsx
+++ b/webmux/frontend/src/components/Tile.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { forwardRef, useImperativeHandle, useState, useCallback, useRef } from 'react';
 import { Terminal, type TerminalHandle } from './Terminal';
 import { useInputBroadcast } from '../contexts/InputBroadcastContext';
 import { api } from '../utils/api';
@@ -15,7 +15,20 @@ interface TileProps {
   isDropTarget?: boolean;
 }
 
-export function Tile({ session, fontSize, onClose, onReconnect, onRename, onTitleMouseDown, isDragging, isDropTarget }: TileProps) {
+export interface TileHandle {
+  focusTerminal: () => void;
+}
+
+export const Tile = forwardRef<TileHandle, TileProps>(function Tile({
+  session,
+  fontSize,
+  onClose,
+  onReconnect,
+  onRename,
+  onTitleMouseDown,
+  isDragging,
+  isDropTarget,
+}: TileProps, ref) {
   const [state, setState] = useState<ConnectionState>(session.state);
   const [viewerCount, setViewerCount] = useState(1);
   const [editing, setEditing] = useState(false);
@@ -26,6 +39,12 @@ export function Tile({ session, fontSize, onClose, onReconnect, onRename, onTitl
   const inputRef = useRef<HTMLInputElement>(null);
 
   const isFocused = focusedSessionId === session.id;
+
+  useImperativeHandle(ref, () => ({
+    focusTerminal: () => {
+      termHandleRef.current?.focus();
+    },
+  }));
 
   const handleStateChange = useCallback((newState: ConnectionState) => {
     setState(newState);
@@ -188,7 +207,7 @@ export function Tile({ session, fontSize, onClose, onReconnect, onRename, onTitl
       </div>
     </div>
   );
-}
+});
 
 const styles: Record<string, React.CSSProperties> = {
   tile: {

--- a/webmux/frontend/src/components/Workspace.tsx
+++ b/webmux/frontend/src/components/Workspace.tsx
@@ -57,6 +57,12 @@ function isEditableTarget(target: EventTarget | null): boolean {
   return Boolean(target.closest('input, textarea, select, [role="textbox"]'));
 }
 
+function terminalCycleDirectionFromKey(e: KeyboardEvent): 1 | -1 | null {
+  if (e.code === 'Period' || e.key === '>' || e.key === '.') return 1;
+  if (e.code === 'Comma' || e.key === '<' || e.key === ',') return -1;
+  return null;
+}
+
 function AddCell({ row, col, isEmpty, onClick }: {
   row: number;
   col: number;
@@ -159,13 +165,14 @@ export function Workspace({ fontSize, termCols, termRows }: WorkspaceProps) {
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.defaultPrevented || !e.ctrlKey || !e.shiftKey || e.altKey || e.metaKey) return;
-      if (e.code !== 'Comma' && e.code !== 'Period') return;
+      const direction = terminalCycleDirectionFromKey(e);
+      if (direction === null) return;
       if (isEditableTarget(e.target)) return;
       if (!gridRef.current || gridRef.current.offsetParent === null) return;
 
       e.preventDefault();
       e.stopPropagation();
-      cycleFocusedSession(e.code === 'Period' ? 1 : -1);
+      cycleFocusedSession(direction);
     };
 
     window.addEventListener('keydown', onKeyDown, true);

--- a/webmux/frontend/src/components/Workspace.tsx
+++ b/webmux/frontend/src/components/Workspace.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { Tile } from './Tile';
+import { Tile, type TileHandle } from './Tile';
 import { ConnectionDialog } from './ConnectionDialog';
 import { api } from '../utils/api';
+import { useInputBroadcast } from '../contexts/InputBroadcastContext';
 import type { Session, CreateSessionRequest } from '../types';
 
 interface WorkspaceProps {
@@ -43,6 +44,17 @@ function getAddPositions(sessions: Session[]): { row: number; col: number }[] {
   }
 
   return positions;
+}
+
+function orderedSessions(sessions: Session[]): Session[] {
+  return [...sessions].sort((a, b) => a.row - b.row || a.col - b.col);
+}
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.closest('.xterm')) return false;
+  if (target.isContentEditable) return true;
+  return Boolean(target.closest('input, textarea, select, [role="textbox"]'));
 }
 
 function AddCell({ row, col, isEmpty, onClick }: {
@@ -99,7 +111,7 @@ export function Workspace({ fontSize, termCols, termRows }: WorkspaceProps) {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [loading, setLoading] = useState(true);
   const [dialogPos, setDialogPos] = useState<{ row: number; col: number } | null>(null);
-
+  const { focusedSessionId, setFocusedSessionId } = useInputBroadcast();
 
   // Drag state
   const [draggingId, setDraggingId] = useState<string | null>(null);
@@ -111,8 +123,11 @@ export function Workspace({ fontSize, termCols, termRows }: WorkspaceProps) {
   const sessionsRef = useRef<Session[]>([]);
   const draggingIdRef = useRef<string | null>(null);
   const dropTargetRef = useRef<{ row: number; col: number } | null>(null);
+  const tileRefs = useRef(new Map<string, TileHandle>());
+  const focusedSessionIdRef = useRef<string | null>(null);
   useEffect(() => { sessionsRef.current = sessions; }, [sessions]);
   useEffect(() => { draggingIdRef.current = draggingId; }, [draggingId]);
+  useEffect(() => { focusedSessionIdRef.current = focusedSessionId; }, [focusedSessionId]);
   useEffect(() => {
     dropTargetRef.current = dropTarget;
   }, [dropTarget]);
@@ -123,6 +138,39 @@ export function Workspace({ fontSize, termCols, termRows }: WorkspaceProps) {
       .catch(err => console.error('Failed to load sessions:', err))
       .finally(() => setLoading(false));
   }, []);
+
+  const focusSession = useCallback((sessionId: string) => {
+    focusedSessionIdRef.current = sessionId;
+    setFocusedSessionId(sessionId);
+    tileRefs.current.get(sessionId)?.focusTerminal();
+  }, [setFocusedSessionId]);
+
+  const cycleFocusedSession = useCallback((direction: 1 | -1) => {
+    const ordered = orderedSessions(sessionsRef.current);
+    if (ordered.length === 0) return;
+
+    const currentIndex = ordered.findIndex(session => session.id === focusedSessionIdRef.current);
+    const nextIndex = currentIndex === -1
+      ? (direction === 1 ? 0 : ordered.length - 1)
+      : (currentIndex + direction + ordered.length) % ordered.length;
+    focusSession(ordered[nextIndex].id);
+  }, [focusSession]);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.defaultPrevented || !e.ctrlKey || !e.shiftKey || e.altKey || e.metaKey) return;
+      if (e.code !== 'Comma' && e.code !== 'Period') return;
+      if (isEditableTarget(e.target)) return;
+      if (!gridRef.current || gridRef.current.offsetParent === null) return;
+
+      e.preventDefault();
+      e.stopPropagation();
+      cycleFocusedSession(e.code === 'Period' ? 1 : -1);
+    };
+
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+  }, [cycleFocusedSession]);
 
   const handleAddSession = useCallback(async (req: CreateSessionRequest) => {
     const session = await api.createSession(req);
@@ -284,6 +332,10 @@ export function Workspace({ fontSize, termCols, termRows }: WorkspaceProps) {
             }}
           >
             <Tile
+              ref={handle => {
+                if (handle) tileRefs.current.set(session.id, handle);
+                else tileRefs.current.delete(session.id);
+              }}
               session={session}
               fontSize={fontSize}
               onClose={handleClose}

--- a/webmux/frontend/src/test/setup.ts
+++ b/webmux/frontend/src/test/setup.ts
@@ -1,4 +1,10 @@
 import '@testing-library/jest-dom';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});
 
 // Ensure localStorage is available in jsdom test environment
 if (typeof globalThis.localStorage === 'undefined' || typeof globalThis.localStorage.getItem !== 'function') {


### PR DESCRIPTION
## Summary
- Add keyboard shortcuts to cycle terminal focus left-to-right and top-to-bottom.
- Focus the target xterm instance when cycling so keyboard input follows the selected tile.
- Accept both physical comma/period key codes and shifted punctuation values for `Ctrl+Shift+<` / `Ctrl+Shift+>`.
- Keep the full test suite deterministic by awaiting session event writes and explicitly cleaning up frontend renders.

## Testing
- `make test`