### PR TITLE
feat: add terminal prompt favicon

### DIFF
--- a/webmux/backend/src/services/sessionBroker.ts
+++ b/webmux/backend/src/services/sessionBroker.ts
@@ -138,7 +138,7 @@ export class SessionBroker extends EventEmitter {
     }
 
     this.persistSessions();
-    persistence.appendEvent({ type: 'session_created', session_id: id, hostname, username: req.username });
+    await persistence.appendEvent({ type: 'session_created', session_id: id, hostname, username: req.username });
     this.emit('session_created', session);
     return session;
   }
@@ -243,7 +243,7 @@ export class SessionBroker extends EventEmitter {
     }
     this.persistSessions();
     this.updateLayout(sessionId);
-    persistence.appendEvent({ type: 'session_deleted', session_id: sessionId });
+    await persistence.appendEvent({ type: 'session_deleted', session_id: sessionId });
     this.emit('session_deleted', sessionId);
   }
 

--- a/webmux/frontend/index.html
+++ b/webmux/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>WebMux</title>
     <style>
       *, *::before, *::after { box-sizing: border-box; }

--- a/webmux/frontend/public/favicon.svg
+++ b/webmux/frontend/public/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="10" fill="#0d0d1a"/>
+  <text
+    x="32"
+    y="39"
+    fill="#e0e0e0"
+    font-family="Consolas, Menlo, DejaVu Sans Mono, monospace"
+    font-size="30"
+    font-weight="700"
+    text-anchor="middle"
+  >&gt;_</text>
+</svg>

--- a/webmux/frontend/src/test/setup.ts
+++ b/webmux/frontend/src/test/setup.ts
@@ -1,4 +1,10 @@
 import '@testing-library/jest-dom';
+import { cleanup } from '@testing-library/react';
+import { afterEach } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});
 
 // Ensure localStorage is available in jsdom test environment
 if (typeof globalThis.localStorage === 'undefined' || typeof globalThis.localStorage.getItem !== 'function') {


### PR DESCRIPTION
## Summary
- Add a crisp SVG favicon using a terminal prompt `>_` mark.
- Link the favicon from the frontend HTML so Vite copies it into the built web assets.
- Keep the full test suite deterministic by awaiting session event writes and explicitly cleaning up frontend renders.

## Testing
- `make test`
