### PR TITLE
Add configurable tmux-backed agent session views

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ A web-native terminal multiplexer — think tmux-on-a-jump-box, but it runs in y
 - **OS service integration** — `make install` sets up launchd (macOS) or systemd (Linux) for auto-start on boot
 - **YAML configuration** — human-editable config in `~/.config/webmux/`, separate from the source tree
 - **Audit log** — append-only JSONL event log (logins, session lifecycle)
+- **Optional agent views** — disabled-by-default tmux-backed agent session browser with attach and scratch-shell support
 
 ## Quick Start
 
@@ -103,6 +104,8 @@ app:
 The `default_term` settings control the size of every terminal tile. Each tile is rendered at a fixed pixel size derived from `cols`, `rows`, and `font_size`. When tiles exceed the browser viewport, the workspace scrolls horizontally and vertically. All three values can also be adjusted live from the top bar — changes are saved back to `app.yaml` automatically.
 
 The optional `terminal_grid` settings cap the number of columns and rows available in the terminals workspace. By default both directions are unlimited. `WEBMUX_TERMINAL_GRID_MAX_COLS` and `WEBMUX_TERMINAL_GRID_MAX_ROWS` override the YAML values at runtime; set either variable to a positive integer, or to `0`/`unlimited` for no limit.
+
+Optional tmux-backed agent views are configured under `app.agents` and are disabled by default. See [Agent Views](docs/agent-views.md) and the sample config at [webmux/examples/agent-views/app.yaml](webmux/examples/agent-views/app.yaml).
 
 ### `auth.yaml` — Authentication
 
@@ -205,6 +208,11 @@ webmux/                          Source / install directory (WEBMUX_ROOT)
 | `PUT` | `/api/config` | Update app config |
 | `GET` | `/api/config/layout` | Get layout |
 | `PUT` | `/api/config/layout` | Update layout |
+| `GET` | `/api/agents/config` | Get normalized agent-view config |
+| `GET` | `/api/agents/sessions` | List configured agent tmux sessions |
+| `GET` | `/api/agents/:agentId/sessions` | List sessions for one configured agent |
+| `POST` | `/api/agents/:agentId/attach` | Attach to a validated tmux session |
+| `POST` | `/api/agents/:agentId/scratch` | Open or reuse an agent scratch shell |
 
 ### WebSocket
 

--- a/docs/agent-views.md
+++ b/docs/agent-views.md
@@ -1,0 +1,238 @@
+# Agent Views
+
+Agent views let WebMux list and attach to agent runtime sessions that already
+exist in named tmux servers. The feature is disabled by default. When enabled,
+WebMux adds an Agents workspace that can attach to a selected tmux session and
+open a scratch shell beside it.
+
+The agent attach sessions are internal WebMux sessions. They do not appear in
+the normal terminal grid, do not occupy terminal layout cells, and are launched
+with `exec_argv` instead of shell-interpolated command strings.
+
+## Runtime Requirements
+
+- `tmux` installed on the WebMux host.
+- Agent sessions running inside configured tmux servers.
+- WebMux access to the same user account or tmux socket path.
+
+## Configuration
+
+Agent views are configured in `WEBMUX_HOME/config/app.yaml`:
+
+```yaml
+app:
+  ui:
+    default_pane: terminals
+    host_switcher:
+      enabled: false
+      suffixes: []
+      hosts: []
+  agents:
+    enabled: true
+    combined_pane: true
+    disable_in_multi_user_mode: true
+    definitions:
+      - id: codex
+        label: Codex
+        plural_label: Codex Sessions
+        badge: CODEX
+        tmux_socket: codex
+```
+
+Definition fields:
+
+- `id`: stable lowercase ID used in URLs and status metadata.
+- `label`: human label for errors and UI text.
+- `plural_label`: pane or list label.
+- `badge`: short badge shown beside sessions.
+- `tmux_socket`: tmux `-L` socket name or absolute `-S` socket path.
+- `workspace`: optional pane key. If omitted, WebMux derives `agent-<id>`.
+- `enabled`: optional per-definition toggle. Defaults to `true`.
+
+`combined_pane: true` shows one Agents pane for all enabled definitions.
+Set it to `false` to show one top-bar button per definition.
+
+Keep `ui.default_pane: terminals` for the upstream default. If you set it to
+`agents`, make sure agents are enabled and at least one definition exists.
+
+## Starting Agent Sessions
+
+Create a named tmux server and session before opening WebMux:
+
+```bash
+tmux -L codex new-session -d -s codex-review
+tmux -L codex attach-session -t codex-review
+```
+
+Start the agent runtime inside that tmux session. WebMux lists live sessions
+from:
+
+```bash
+tmux -L codex list-sessions
+```
+
+When a user attaches from WebMux, the backend first validates the requested
+session name against live `tmux list-sessions` output, then launches:
+
+```bash
+tmux -L codex attach-session -t codex-review
+```
+
+as an argv array.
+
+## Scratch Shells
+
+The Agents workspace can open a scratch shell next to the selected agent
+session. When possible, WebMux asks tmux for the selected pane's
+`#{pane_current_path}` and starts the scratch shell in that directory.
+
+## Optional Status Hooks
+
+Agent views work without hooks. Without hooks, WebMux falls back to tmux
+session activity timestamps for recency and status.
+
+For runtimes with Codex-style hooks, install the optional status writer:
+
+```bash
+install -m 0755 webmux/scripts/webmux-agent-status.js ~/.local/bin/webmux-agent-status
+```
+
+Example hook commands:
+
+```bash
+webmux-agent-status --agent codex --tmux-socket codex --status working
+webmux-agent-status --agent codex --tmux-socket codex --status waiting
+```
+
+The script writes JSON metadata under:
+
+```text
+WEBMUX_HOME/data/agent-status/<agent-id>/<encoded-session-name>.json
+```
+
+If the agent runtime sends JSON on stdin with `session_id` or `turn_id`, the
+script stores those values as optional hook metadata.
+
+## Host Switcher
+
+The host switcher is also disabled by default. Enable it only with public or
+site-local names you intend to show in the UI:
+
+```yaml
+app:
+  ui:
+    host_switcher:
+      enabled: true
+      suffixes:
+        - example.net
+      hosts:
+        - id: lab-a
+          label: Lab A
+          hostname: lab-a-webmux.example.net
+        - id: lab-b
+          label: Lab B
+          hostname: lab-b-webmux.example.net
+        - id: gpu-box
+          label: GPU Box
+          hostname: gpu-box-webmux.example.net
+        - id: workstation
+          label: Workstation
+          hostname: workstation-webmux.example.net
+```
+
+This is only a link switcher. It does not configure reverse proxies or tunnels.
+
+## Security Notes
+
+Agent attach exposes local tmux sessions and a local scratch shell to the WebMux
+user. For that reason:
+
+- `app.agents.enabled` defaults to `false`.
+- `app.agents.disable_in_multi_user_mode` defaults to `true`.
+- Attach requests are validated against live tmux sessions before launch.
+- Attach commands use `exec_argv`, not shell string interpolation.
+- Use local auth and HTTPS when exposing WebMux beyond a trusted host or LAN.
+- Only configure tmux sockets that WebMux users are allowed to access.
+
+To allow agent routes in multi-user mode, set:
+
+```yaml
+app:
+  agents:
+    disable_in_multi_user_mode: false
+```
+
+Do this only when the WebMux account model and tmux socket permissions match
+your deployment policy.
+
+## Setup For Agents
+
+1. Install tmux:
+
+```bash
+sudo apt install tmux
+```
+
+2. Create a named tmux session:
+
+```bash
+tmux -L codex new-session -d -s codex-review
+```
+
+3. Configure `WEBMUX_HOME/config/app.yaml`:
+
+```yaml
+app:
+  agents:
+    enabled: true
+    combined_pane: true
+    disable_in_multi_user_mode: true
+    definitions:
+      - id: codex
+        label: Codex
+        plural_label: Codex Sessions
+        badge: CODEX
+        tmux_socket: codex
+```
+
+4. Optionally install the hook script:
+
+```bash
+install -m 0755 webmux/scripts/webmux-agent-status.js ~/.local/bin/webmux-agent-status
+```
+
+5. Restart WebMux:
+
+```bash
+make restart
+```
+
+6. Verify the API:
+
+```bash
+curl http://localhost:8080/api/agents/sessions
+```
+
+7. Open WebMux and select the Agents pane.
+
+## Example Reverse Proxy Snippet
+
+This example uses fake public hostnames and is not a production recommendation:
+
+```nginx
+server {
+  listen 443 ssl;
+  server_name lab-a-webmux.example.net;
+
+  location / {
+    proxy_pass http://127.0.0.1:8080;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+  }
+}
+```
+
+Use your normal TLS, authentication, and network controls for any real
+deployment.

--- a/tests/backend/agentApi.test.ts
+++ b/tests/backend/agentApi.test.ts
@@ -245,6 +245,23 @@ describe('Agent API Routes', () => {
     expect(res.body.error).toBe('Codex session not found');
   });
 
+  it('purges existing agent sessions when generic reconnect is denied', async () => {
+    mockTmux('codex-a\t1\t0\t1781474936\t1781725677\n');
+    const attach = await request(app)
+      .post('/api/agents/codex/attach')
+      .send({ name: 'codex-a' });
+    expect(attach.status).toBe(201);
+
+    writeAppConfig(false);
+    const res = await request(app)
+      .post(`/api/sessions/${attach.body.id}/reconnect`)
+      .send({});
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Agent sessions are not enabled');
+    expect(sessionBroker.get(attach.body.id)).toBeUndefined();
+  });
+
   it('opens scratch shells in the selected tmux pane cwd when available', async () => {
     mockTmux('codex-a\t1\t0\t1781474936\t1781725677\n');
 

--- a/tests/backend/agentApi.test.ts
+++ b/tests/backend/agentApi.test.ts
@@ -1,0 +1,267 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import express from 'express';
+import request from 'supertest';
+
+const mockExecFile = jest.fn();
+const mockExecSync = jest.fn();
+
+jest.mock('child_process', () => ({
+  execFile: mockExecFile,
+  execSync: mockExecSync,
+}));
+
+describe('Agent API Routes', () => {
+  let tmpDir: string;
+  let originalHome: string | undefined;
+  let originalShell: string | undefined;
+  let app: express.Express;
+  let sessionBroker: any;
+  let transportLauncher: any;
+  let dateNowSpy: jest.SpyInstance<number, []>;
+
+  beforeEach(async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webmux-agents-'));
+    originalHome = process.env.WEBMUX_HOME;
+    originalShell = process.env.SHELL;
+    process.env.WEBMUX_HOME = tmpDir;
+    process.env.SHELL = '/bin/test-shell';
+    dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-06-17T20:10:00.000Z'));
+
+    const configDir = path.join(tmpDir, 'config');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'auth.yaml'), 'auth:\n  mode: none\n  users: []\n');
+    fs.writeFileSync(path.join(configDir, 'hosts.yaml'), 'hosts: []\n');
+    fs.writeFileSync(path.join(configDir, 'keys.yaml'), 'keys: []\n');
+    fs.writeFileSync(path.join(configDir, 'layout.yaml'), 'layout:\n  font_size: 14\n  tiles: []\n');
+    writeAppConfig(true);
+
+    mockExecFile.mockReset();
+    mockExecSync.mockReset();
+    jest.resetModules();
+
+    const { default: agentsRouter } = require('@backend/api/agents');
+    const { default: sessionsRouter } = require('@backend/api/sessions');
+    sessionBroker = require('@backend/services/sessionBroker').sessionBroker;
+    transportLauncher = require('@backend/services/transportLauncher').transportLauncher;
+
+    await sessionBroker.initialize();
+
+    app = express();
+    app.use(express.json());
+    app.use('/api/agents', agentsRouter);
+    app.use('/api/sessions', sessionsRouter);
+  });
+
+  afterEach(() => {
+    if (sessionBroker && transportLauncher) {
+      for (const session of sessionBroker.list()) {
+        transportLauncher.kill(session.id);
+      }
+    }
+    if (originalHome === undefined) {
+      delete process.env.WEBMUX_HOME;
+    } else {
+      process.env.WEBMUX_HOME = originalHome;
+    }
+    if (originalShell === undefined) {
+      delete process.env.SHELL;
+    } else {
+      process.env.SHELL = originalShell;
+    }
+    dateNowSpy.mockRestore();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeAppConfig(enabled: boolean, disableInMultiUserMode = true) {
+    fs.writeFileSync(
+      path.join(tmpDir, 'config', 'app.yaml'),
+      'app:\n' +
+        '  name: webmux\n' +
+        '  listen_host: 0.0.0.0\n' +
+        '  http_port: 8080\n' +
+        '  https_port: 8443\n' +
+        '  secure_mode: false\n' +
+        '  trusted_http_allowed: true\n' +
+        '  default_term:\n' +
+        '    cols: 80\n' +
+        '    rows: 24\n' +
+        '    font_size: 14\n' +
+        '  ui:\n' +
+        '    default_pane: terminals\n' +
+        '    host_switcher:\n' +
+        '      enabled: false\n' +
+        '      suffixes: []\n' +
+        '      hosts: []\n' +
+        '  agents:\n' +
+        `    enabled: ${enabled}\n` +
+        '    combined_pane: true\n' +
+        `    disable_in_multi_user_mode: ${disableInMultiUserMode}\n` +
+        '    definitions:\n' +
+        '      - id: codex\n' +
+        '        label: Codex\n' +
+        '        plural_label: Codex Sessions\n' +
+        '        badge: CODEX\n' +
+        '        tmux_socket: codex\n' +
+        '  transport:\n' +
+        '    prefer_mosh: false\n' +
+        '    ssh_fallback: true\n' +
+        '    mosh_server_path: ""\n',
+    );
+  }
+
+  function writeAuthConfig(content: string) {
+    fs.writeFileSync(path.join(tmpDir, 'config', 'auth.yaml'), content);
+  }
+
+  function authHeader(username = 'a') {
+    const { signToken } = require('@backend/middleware/auth');
+    return { Authorization: `Bearer ${signToken(username)}` };
+  }
+
+  function mockTmux(output: string) {
+    mockExecFile.mockImplementation((_cmd: string, args: string[], _options: unknown, callback: (err: Error | null, stdout?: string) => void) => {
+      if (args.includes('list-sessions')) {
+        callback(null, output);
+        return;
+      }
+      if (args.includes('display-message')) {
+        callback(null, `${tmpDir}\n`);
+        return;
+      }
+      callback(null, '');
+    });
+  }
+
+  it('returns normalized configured agent definitions', async () => {
+    const res = await request(app).get('/api/agents/config');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      enabled: true,
+      combined_pane: true,
+      disable_in_multi_user_mode: true,
+      definitions: [
+        {
+          id: 'codex',
+          label: 'Codex',
+          plural_label: 'Codex Sessions',
+          badge: 'CODEX',
+          tmux_socket: 'codex',
+          workspace: 'agent-codex',
+          enabled: true,
+        },
+      ],
+    });
+  });
+
+  it('lists tmux sessions through the configured socket', async () => {
+    mockTmux('codex-alpha-2026-06-14-15-08-55\t1\t2\t1781474936\t1781725677\n');
+
+    const res = await request(app).get('/api/agents/codex/sessions');
+
+    expect(res.status).toBe(200);
+    expect(mockExecFile).toHaveBeenCalledWith(
+      'tmux',
+      ['-L', 'codex', 'list-sessions', '-F', '#S\t#{session_windows}\t#{session_attached}\t#{session_created}\t#{session_activity}'],
+      { encoding: 'utf8' },
+      expect.any(Function),
+    );
+    expect(res.body).toEqual([
+      {
+        name: 'codex-alpha-2026-06-14-15-08-55',
+        agent_id: 'codex',
+        display_name: 'alpha',
+        windows: 1,
+        attached: 2,
+        created_at: '2026-06-14T22:08:56.000Z',
+        last_output_at: '2026-06-17T19:47:57.000Z',
+        status: 'unknown',
+        status_source: 'tmux',
+      },
+    ]);
+  });
+
+  it('keeps agent routes disabled when app.agents.enabled is false', async () => {
+    writeAppConfig(false);
+
+    const res = await request(app).get('/api/agents/sessions').set(authHeader());
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Agent sessions are not enabled');
+  });
+
+  it('denies agent routes in multi-user mode by default', async () => {
+    writeAuthConfig('auth:\n  mode: local\n  users:\n    - username: a\n      password_hash: x\n    - username: b\n      password_hash: y\n');
+
+    const res = await request(app).get('/api/agents/sessions').set(authHeader());
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('Agent sessions are disabled in multi-user mode');
+  });
+
+  it('allows explicit multi-user opt-in', async () => {
+    writeAppConfig(true, false);
+    writeAuthConfig('auth:\n  mode: local\n  users:\n    - username: a\n      password_hash: x\n    - username: b\n      password_hash: y\n');
+    mockTmux('');
+
+    const res = await request(app).get('/api/agents/sessions').set(authHeader());
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('validates a live tmux session before attaching with exec argv', async () => {
+    mockTmux('codex-a\t1\t0\t1781474936\t1781725677\n');
+
+    const res = await request(app)
+      .post('/api/agents/codex/attach')
+      .send({ name: 'codex-a', cols: 100, rows: 30 });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      transport: 'exec',
+      title: 'codex-a',
+      state: 'connected',
+      persistent: false,
+      workspace: 'agent-codex',
+      agent_id: 'codex',
+      agent_role: 'attach',
+      agent_session_name: 'codex-a',
+      exec_argv: ['tmux', '-L', 'codex', 'attach-session', '-t', 'codex-a'],
+    });
+    expect(res.body.exec_command).toBeUndefined();
+  });
+
+  it('rejects attach for a session not present in live tmux output', async () => {
+    mockTmux('codex-a\t1\t0\t1781474936\t1781725677\n');
+
+    const res = await request(app)
+      .post('/api/agents/codex/attach')
+      .send({ name: 'codex-missing' });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Codex session not found');
+  });
+
+  it('opens scratch shells in the selected tmux pane cwd when available', async () => {
+    mockTmux('codex-a\t1\t0\t1781474936\t1781725677\n');
+
+    const res = await request(app)
+      .post('/api/agents/codex/scratch')
+      .send({ selectedName: 'codex-a', cols: 80, rows: 24 });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({
+      transport: 'exec',
+      title: 'Scratch shell',
+      persistent: false,
+      workspace: 'agent-codex',
+      agent_id: 'codex',
+      agent_role: 'scratch',
+      exec_argv: ['/bin/test-shell', '-l'],
+      exec_cwd: tmpDir,
+    });
+  });
+});

--- a/tests/backend/sessionBroker.test.ts
+++ b/tests/backend/sessionBroker.test.ts
@@ -6,6 +6,7 @@ describe('SessionBroker', () => {
   let tmpDir: string;
   let originalHome: string | undefined;
   let SessionBroker: typeof import('@backend/services/sessionBroker').SessionBroker;
+  let transportLauncher: typeof import('@backend/services/transportLauncher').transportLauncher;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'webmux-broker-'));
@@ -22,6 +23,9 @@ describe('SessionBroker', () => {
 
     jest.resetModules();
     ({ SessionBroker } = require('@backend/services/sessionBroker'));
+    ({ transportLauncher } = require('@backend/services/transportLauncher'));
+    (SessionBroker as unknown as Record<string, number>).AGENT_ATTACH_REPLAY_SUPPRESS_MS = 1500;
+    (SessionBroker as unknown as Record<string, number>).AGENT_STATUS_FLUSH_DEBOUNCE_MS = 1;
   });
 
   afterEach(() => {
@@ -32,6 +36,23 @@ describe('SessionBroker', () => {
     }
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
+
+  function encodedStatusName(name: string) {
+    return Buffer.from(name, 'utf8')
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/g, '');
+  }
+
+  function readAgentStatus(agentId: string, name: string) {
+    const file = path.join(tmpDir, 'data', 'agent-status', agentId, `${encodedStatusName(name)}.json`);
+    return JSON.parse(fs.readFileSync(file, 'utf8')) as Record<string, unknown>;
+  }
+
+  function sleep(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+  }
 
   it('initializes with no sessions', async () => {
     const broker = new SessionBroker();
@@ -135,6 +156,169 @@ describe('SessionBroker', () => {
     const session = await broker.create({ username: 'u', hostname: 'h' });
 
     expect(() => broker.move(session.id, 0, 1)).toThrow('exceeds max_cols 1');
+  });
+
+  it('keeps agent workspace sessions out of terminal lists and layout compaction', async () => {
+    const broker = new SessionBroker();
+    await broker.initialize();
+    const first = await broker.create({ username: 'u', hostname: 'h', row: 0, col: 0 });
+    const second = await broker.create({ username: 'u', hostname: 'h', row: 2, col: 0 });
+    const { session: agent } = await broker.ensureAgentScratch('anonymous', 'codex', 'agent-codex', 80, 24, tmpDir);
+
+    expect(broker.list()).toHaveLength(3);
+    expect(broker.listByOwner('anonymous').map(s => s.id)).toEqual([first.id, second.id]);
+
+    await broker.delete(agent.id);
+
+    expect(broker.get(first.id)!.row).toBe(0);
+    expect(broker.get(first.id)!.col).toBe(0);
+    expect(broker.get(second.id)!.row).toBe(2);
+    expect(broker.get(second.id)!.col).toBe(0);
+  });
+
+  it('rejects moves for agent workspace sessions', async () => {
+    const broker = new SessionBroker();
+    await broker.initialize();
+    const { session } = await broker.ensureAgentAttach(
+      'anonymous',
+      'codex',
+      'agent-codex',
+      'codex-a',
+      80,
+      24,
+      ['tmux', '-L', 'codex', 'attach-session', '-t', 'codex-a'],
+    );
+
+    expect(() => broker.move(session.id, 1, 1)).toThrow('Agent workspace sessions cannot be moved');
+  });
+
+  it('marks agent attach sessions connected immediately after launch', async () => {
+    const broker = new SessionBroker();
+    await broker.initialize();
+    const { session } = await broker.ensureAgentAttach(
+      'anonymous',
+      'codex',
+      'agent-codex',
+      'codex-a',
+      80,
+      24,
+      ['tmux', '-L', 'codex', 'attach-session', '-t', 'codex-a'],
+    );
+
+    expect(session.state).toBe('connected');
+  });
+
+  it('does not touch updated_at when reusing the same live agent attach at the same size', async () => {
+    const broker = new SessionBroker();
+    await broker.initialize();
+    const first = await broker.ensureAgentAttach(
+      'anonymous',
+      'codex',
+      'agent-codex',
+      'codex-a',
+      80,
+      24,
+      ['tmux', '-L', 'codex', 'attach-session', '-t', 'codex-a'],
+    );
+    first.session.updated_at = '2026-06-17T20:00:00.000Z';
+    const handle = transportLauncher.getHandle(first.session.id)!;
+    const resizeSpy = jest.spyOn(handle, 'resize');
+
+    const second = await broker.ensureAgentAttach(
+      'anonymous',
+      'codex',
+      'agent-codex',
+      'codex-a',
+      80,
+      24,
+      ['tmux', '-L', 'codex', 'attach-session', '-t', 'codex-a'],
+    );
+
+    expect(second.session.id).toBe(first.session.id);
+    expect(resizeSpy).not.toHaveBeenCalled();
+    expect(second.session.updated_at).toBe('2026-06-17T20:00:00.000Z');
+  });
+
+  it('ignores stale PTY exit events after relaunching an agent attach session', async () => {
+    const broker = new SessionBroker();
+    await broker.initialize();
+    const first = await broker.ensureAgentAttach(
+      'anonymous',
+      'codex',
+      'agent-codex',
+      'codex-a',
+      80,
+      24,
+      ['tmux', '-L', 'codex', 'attach-session', '-t', 'codex-a'],
+    );
+    const staleHandle = transportLauncher.getHandle(first.session.id) as unknown as { emit: (event: string, data: unknown) => void };
+
+    const second = await broker.ensureAgentAttach(
+      'anonymous',
+      'codex',
+      'agent-codex',
+      'codex-b',
+      80,
+      24,
+      ['tmux', '-L', 'codex', 'attach-session', '-t', 'codex-b'],
+    );
+
+    expect(second.session.id).toBe(first.session.id);
+    staleHandle.emit('exit', { exitCode: 0 });
+    expect(broker.get(first.session.id)!.state).toBe('connected');
+
+    const currentHandle = transportLauncher.getHandle(first.session.id) as unknown as { emit: (event: string, data: unknown) => void };
+    currentHandle.emit('exit', { exitCode: 0 });
+    expect(broker.get(first.session.id)!.state).toBe('disconnected');
+  });
+
+  it('does not record agent output metadata from tmux attach replay', async () => {
+    const broker = new SessionBroker();
+    await broker.initialize();
+    const { session } = await broker.ensureAgentAttach(
+      'anonymous',
+      'codex',
+      'agent-codex',
+      'codex-a',
+      80,
+      24,
+      ['tmux', '-L', 'codex', 'attach-session', '-t', 'codex-a'],
+    );
+    const handle = transportLauncher.getHandle(session.id) as unknown as { emit: (event: string, data: unknown) => void };
+
+    handle.emit('data', 'tmux screen replay');
+    await sleep(25);
+
+    expect(fs.existsSync(path.join(tmpDir, 'data', 'agent-status', 'codex'))).toBe(false);
+  });
+
+  it('records live agent output metadata after tmux attach replay', async () => {
+    (SessionBroker as unknown as Record<string, number>).AGENT_ATTACH_REPLAY_SUPPRESS_MS = 1;
+    const broker = new SessionBroker();
+    await broker.initialize();
+    const { session } = await broker.ensureAgentAttach(
+      'anonymous',
+      'codex',
+      'agent-codex',
+      'codex-a',
+      80,
+      24,
+      ['tmux', '-L', 'codex', 'attach-session', '-t', 'codex-a'],
+    );
+    const handle = transportLauncher.getHandle(session.id) as unknown as { emit: (event: string, data: unknown) => void };
+
+    await sleep(5);
+    handle.emit('data', 'live agent output');
+    await sleep(25);
+
+    expect(readAgentStatus('codex', 'codex-a')).toMatchObject({
+      agent_id: 'codex',
+      name: 'codex-a',
+      status: 'working',
+      source: 'webmux',
+      last_output_source: 'live',
+    });
+    expect(typeof readAgentStatus('codex', 'codex-a').last_output_at).toBe('string');
   });
 
   it('persists sessions to disk', async () => {

--- a/tests/backend/sessionBroker.test.ts
+++ b/tests/backend/sessionBroker.test.ts
@@ -239,6 +239,43 @@ describe('SessionBroker', () => {
     expect(second.session.updated_at).toBe('2026-06-17T20:00:00.000Z');
   });
 
+  it('relaunches a live agent attach when the exec argv changes', async () => {
+    const broker = new SessionBroker();
+    await broker.initialize();
+    const first = await broker.ensureAgentAttach(
+      'anonymous',
+      'codex',
+      'agent-codex',
+      'codex-a',
+      80,
+      24,
+      ['tmux', '-L', 'codex', 'attach-session', '-t', 'codex-a'],
+    );
+    const staleHandle = transportLauncher.getHandle(first.session.id) as unknown as {
+      emit: (event: string, data: unknown) => void;
+      kill: () => void;
+    };
+    const killSpy = jest.spyOn(staleHandle, 'kill');
+
+    const second = await broker.ensureAgentAttach(
+      'anonymous',
+      'codex',
+      'agent-codex',
+      'codex-a',
+      80,
+      24,
+      ['tmux', '-L', 'codex-alt', 'attach-session', '-t', 'codex-a'],
+    );
+
+    expect(second.session.id).toBe(first.session.id);
+    expect(second.session.exec_argv).toEqual(['tmux', '-L', 'codex-alt', 'attach-session', '-t', 'codex-a']);
+    expect(killSpy).toHaveBeenCalledTimes(1);
+    expect(transportLauncher.getHandle(first.session.id)).not.toBe(staleHandle);
+
+    staleHandle.emit('exit', { exitCode: 0 });
+    expect(broker.get(first.session.id)!.state).toBe('connected');
+  });
+
   it('ignores stale PTY exit events after relaunching an agent attach session', async () => {
     const broker = new SessionBroker();
     await broker.initialize();

--- a/tests/backend/websocketIntegration.test.ts
+++ b/tests/backend/websocketIntegration.test.ts
@@ -149,6 +149,32 @@ describe('WebSocket Integration', () => {
     expect(code).toBe(1008);
   });
 
+  it('rejects WebSocket for denied agent session and purges it', async () => {
+    const { session } = await sessionBroker.ensureAgentAttach(
+      'anonymous',
+      'codex',
+      'agent-codex',
+      'codex-a',
+      80,
+      24,
+      ['tmux', '-L', 'codex', 'attach-session', '-t', 'codex-a'],
+    );
+    const messages: any[] = [];
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/api/term/${session.id}`);
+    ws.on('message', (raw: Buffer) => {
+      messages.push(JSON.parse(raw.toString()));
+    });
+    const closePromise = new Promise<number>((resolve) => {
+      ws.on('close', (code: number) => resolve(code));
+    });
+
+    const code = await closePromise;
+
+    expect(code).toBe(1008);
+    expect(messages).toContainEqual({ type: 'error', message: 'Agent sessions are not enabled' });
+    expect(sessionBroker.get(session.id)).toBeUndefined();
+  });
+
   it('rejects WebSocket for invalid path', async () => {
     const ws = new WebSocket(`ws://127.0.0.1:${port}/api/health`);
     await new Promise<void>((resolve) => {

--- a/tests/frontend/AgentWorkspace.test.tsx
+++ b/tests/frontend/AgentWorkspace.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import type { AgentDefinition, Session } from '@frontend/types';
+import { AgentWorkspace } from '@frontend/components/AgentWorkspace';
+
+const apiMock = vi.hoisted(() => ({
+  getAllAgentSessions: vi.fn(),
+  getAgentSessions: vi.fn(),
+  attachAgentSession: vi.fn(),
+  createAgentScratch: vi.fn(),
+  deleteSession: vi.fn(),
+}));
+
+vi.mock('@frontend/utils/api', () => ({
+  api: apiMock,
+}));
+
+vi.mock('@frontend/components/Terminal', () => ({
+  Terminal: ({ sessionId }: { sessionId: string }) => <div data-testid={`terminal-${sessionId}`}>Terminal {sessionId}</div>,
+}));
+
+const codexDefinition: AgentDefinition = {
+  id: 'codex',
+  label: 'Codex',
+  plural_label: 'Codex Sessions',
+  badge: 'CODEX',
+  tmux_socket: 'codex',
+  workspace: 'agent-codex',
+  enabled: true,
+};
+
+const helperDefinition: AgentDefinition = {
+  id: 'helper',
+  label: 'Helper',
+  plural_label: 'Helper Sessions',
+  badge: 'HELP',
+  tmux_socket: 'helper',
+  workspace: 'agent-helper',
+  enabled: true,
+};
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'agent-session-1',
+    kind: 'terminal',
+    owner: 'anonymous',
+    transport: 'exec',
+    host_id: '',
+    hostname: 'codex.local',
+    port: 0,
+    username: 'codex',
+    key_id: '',
+    cols: 120,
+    rows: 40,
+    row: 0,
+    col: 0,
+    state: 'connected',
+    created_at: '',
+    updated_at: '',
+    title: 'codex-a',
+    persistent: false,
+    minimized: false,
+    workspace: 'agent-codex',
+    agent_id: 'codex',
+    agent_role: 'attach',
+    agent_session_name: 'codex-a',
+    ...overrides,
+  };
+}
+
+function makeAgentSession(agentId: string, name: string, overrides: Record<string, unknown> = {}) {
+  return {
+    name,
+    agent_id: agentId,
+    display_name: name,
+    windows: 1,
+    attached: 0,
+    created_at: '2026-06-14T22:08:55.000Z',
+    last_output_at: '2026-06-17T20:00:00.000Z',
+    status: 'waiting',
+    status_source: 'hook',
+    ...overrides,
+  };
+}
+
+const defaultProps = {
+  fontSize: 14,
+  termCols: 120,
+  termRows: 40,
+  themes: [],
+  globalTheme: null,
+};
+
+describe('AgentWorkspace', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.getAllAgentSessions.mockResolvedValue([makeAgentSession('codex', 'codex-a')]);
+    apiMock.getAgentSessions.mockResolvedValue([makeAgentSession('codex', 'codex-a')]);
+    apiMock.attachAgentSession.mockResolvedValue(makeSession());
+    apiMock.createAgentScratch.mockResolvedValue(makeSession({
+      id: 'agent-scratch-1',
+      title: 'Scratch shell',
+      agent_role: 'scratch',
+      agent_session_name: undefined,
+    }));
+    apiMock.deleteSession.mockResolvedValue(undefined);
+  });
+
+  it('auto-selects the first configured agent session and requests attach', async () => {
+    render(
+      <AgentWorkspace
+        agent={codexDefinition}
+        agentDefinitions={[codexDefinition]}
+        {...defaultProps}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(apiMock.attachAgentSession).toHaveBeenCalledWith('codex', { name: 'codex-a', cols: 120, rows: 40 });
+    });
+    expect(await screen.findByTestId('terminal-agent-session-1')).toBeDefined();
+    expect(screen.getByTestId('agent-layout-codex')).toHaveStyle('grid-template-columns: minmax(0, 1fr)');
+    expect(apiMock.createAgentScratch).not.toHaveBeenCalled();
+  });
+
+  it('opens and closes a scratch shell beside the selected agent session', async () => {
+    render(
+      <AgentWorkspace
+        agent={codexDefinition}
+        agentDefinitions={[codexDefinition]}
+        {...defaultProps}
+      />,
+    );
+
+    await screen.findByTestId('terminal-agent-session-1');
+    fireEvent.click(screen.getByText('+ Shell'));
+
+    await waitFor(() => {
+      expect(apiMock.createAgentScratch).toHaveBeenCalledWith('codex', { selectedName: 'codex-a', cols: 60, rows: 40 });
+    });
+    expect(screen.getByTestId('agent-layout-codex')).toHaveStyle('grid-template-columns: minmax(0, 2fr) minmax(0, 1fr)');
+    expect(await screen.findByTestId('terminal-agent-scratch-1')).toBeDefined();
+
+    fireEvent.click(screen.getByTitle('Close scratch shell'));
+
+    await waitFor(() => {
+      expect(apiMock.deleteSession).toHaveBeenCalledWith('agent-scratch-1');
+    });
+    expect(screen.getByTestId('agent-layout-codex')).toHaveStyle('grid-template-columns: minmax(0, 1fr)');
+  });
+
+  it('renders combined configured agents and attaches by selected agent id', async () => {
+    apiMock.getAllAgentSessions.mockResolvedValue([
+      makeAgentSession('codex', 'codex-a', { display_name: 'codex-a' }),
+      makeAgentSession('helper', 'helper-a', { display_name: 'helper-a' }),
+    ]);
+    apiMock.attachAgentSession
+      .mockResolvedValueOnce(makeSession({ id: 'codex-session', title: 'codex-a', agent_id: 'codex', agent_session_name: 'codex-a' }))
+      .mockResolvedValueOnce(makeSession({
+        id: 'helper-session',
+        title: 'helper-a',
+        username: 'helper',
+        hostname: 'helper.local',
+        workspace: 'agent-helper',
+        agent_id: 'helper',
+        agent_session_name: 'helper-a',
+      }));
+
+    render(
+      <AgentWorkspace
+        agentDefinitions={[codexDefinition, helperDefinition]}
+        {...defaultProps}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(apiMock.attachAgentSession).toHaveBeenCalledWith('codex', { name: 'codex-a', cols: 120, rows: 40 });
+    });
+    expect(screen.getAllByText('codex-a').length).toBeGreaterThan(0);
+    expect(screen.getByText('helper-a')).toBeDefined();
+
+    fireEvent.click(screen.getByText('helper-a'));
+
+    await waitFor(() => {
+      expect(apiMock.attachAgentSession).toHaveBeenCalledWith('helper', { name: 'helper-a', cols: 120, rows: 40 });
+    });
+    expect(await screen.findByTestId('terminal-helper-session')).toBeDefined();
+  });
+
+  it('shows an empty state without opening scratch in a combined pane until a session is selected', async () => {
+    apiMock.getAllAgentSessions.mockResolvedValue([]);
+
+    render(
+      <AgentWorkspace
+        agentDefinitions={[codexDefinition, helperDefinition]}
+        {...defaultProps}
+      />,
+    );
+
+    expect(await screen.findByText('No agent sessions')).toBeDefined();
+    expect(screen.getByText('+ Shell')).toBeDisabled();
+    expect(apiMock.attachAgentSession).not.toHaveBeenCalled();
+    expect(apiMock.createAgentScratch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/frontend/AgentWorkspace.test.tsx
+++ b/tests/frontend/AgentWorkspace.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { act, render, screen, waitFor, fireEvent } from '@testing-library/react';
 import type { AgentDefinition, Session } from '@frontend/types';
 import { AgentWorkspace } from '@frontend/components/AgentWorkspace';
 
@@ -201,5 +201,32 @@ describe('AgentWorkspace', () => {
     expect(screen.getByText('+ Shell')).toBeDisabled();
     expect(apiMock.attachAgentSession).not.toHaveBeenCalled();
     expect(apiMock.createAgentScratch).not.toHaveBeenCalled();
+  });
+
+  it('refreshes per-agent panes on an interval', async () => {
+    vi.useFakeTimers();
+    try {
+      render(
+        <AgentWorkspace
+          agent={codexDefinition}
+          agentDefinitions={[codexDefinition]}
+          {...defaultProps}
+        />,
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(apiMock.getAgentSessions).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        vi.advanceTimersByTime(10000);
+        await Promise.resolve();
+      });
+
+      expect(apiMock.getAgentSessions).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/frontend/App.test.tsx
+++ b/tests/frontend/App.test.tsx
@@ -33,6 +33,11 @@ vi.mock('@frontend/utils/api', () => ({
     getKeys: vi.fn().mockResolvedValue([]),
     getAuthStatus: vi.fn().mockResolvedValue({ mode: 'none', bootstrap_required: false }),
     updateConfig: vi.fn().mockResolvedValue({}),
+    getAllAgentSessions: vi.fn().mockResolvedValue([]),
+    getAgentSessions: vi.fn().mockResolvedValue([]),
+    attachAgentSession: vi.fn(),
+    createAgentScratch: vi.fn(),
+    deleteSession: vi.fn(),
   },
 }));
 
@@ -59,6 +64,16 @@ const defaultConfig = {
     trusted_http_allowed: true,
     default_term: { cols: 80, rows: 24, font_size: 14 },
     terminal_grid: { max_cols: null, max_rows: null },
+    ui: {
+      default_pane: 'terminals',
+      host_switcher: { enabled: false, suffixes: [], hosts: [] },
+    },
+    agents: {
+      enabled: false,
+      combined_pane: true,
+      disable_in_multi_user_mode: true,
+      definitions: [],
+    },
   },
 };
 
@@ -118,6 +133,62 @@ describe('App', () => {
     await waitFor(() => {
       expect(screen.getByText('Click to add a session')).toBeDefined();
     });
+  });
+
+  it('hides the Agents pane by default', async () => {
+    mockAuth.isLoading = false;
+    mockAuth.isAuthenticated = true;
+    mockAuth.authStatus = { mode: 'none', bootstrap_required: false };
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Click to add a session')).toBeDefined();
+    });
+    expect(screen.queryByText('Agents')).toBeNull();
+    expect(api.getAllAgentSessions).not.toHaveBeenCalled();
+  });
+
+  it('shows configured Agents pane when app.agents is enabled', async () => {
+    mockAuth.isLoading = false;
+    mockAuth.isAuthenticated = true;
+    mockAuth.authStatus = { mode: 'none', bootstrap_required: false };
+    (api.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue({
+      app: {
+        ...defaultConfig.app,
+        ui: {
+          default_pane: 'agents',
+          host_switcher: { enabled: false, suffixes: [], hosts: [] },
+        },
+        agents: {
+          enabled: true,
+          combined_pane: true,
+          disable_in_multi_user_mode: true,
+          definitions: [
+            {
+              id: 'codex',
+              label: 'Codex',
+              plural_label: 'Codex Sessions',
+              badge: 'CODEX',
+              tmux_socket: 'codex',
+              workspace: 'agent-codex',
+              enabled: true,
+            },
+          ],
+        },
+      },
+    });
+    (api.getAllAgentSessions as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Agents')).toBeDefined();
+    });
+    await waitFor(() => {
+      expect(api.getAllAgentSessions).toHaveBeenCalledTimes(1);
+    });
+    expect(await screen.findByText('No agent sessions')).toBeDefined();
   });
 
   it('loads config after authentication and applies terminal grid limits', async () => {

--- a/tests/frontend/TopBar.test.tsx
+++ b/tests/frontend/TopBar.test.tsx
@@ -33,6 +33,10 @@ describe('TopBar', () => {
     onNewAccount: vi.fn(),
     secureMode: true,
     currentUser: 'admin',
+    globalAutoScroll: true,
+    onGlobalAutoScrollChange: vi.fn(),
+    globalLock: false,
+    onGlobalLockChange: vi.fn(),
   });
 
   it('renders logo and controls', () => {
@@ -103,5 +107,72 @@ describe('TopBar', () => {
     expect(onTermSizeChange).toHaveBeenCalledWith(80, 29);
     fireEvent.click(screen.getByText('R-'));
     expect(onTermSizeChange).toHaveBeenCalledWith(80, 19);
+  });
+
+  it('does not show agent buttons without configured definitions', () => {
+    render(<TopBar {...defaultTopBarProps()} />, { wrapper });
+    expect(screen.queryByText('Agents')).toBeNull();
+  });
+
+  it('shows a combined Agents button for configured agents', () => {
+    render(
+      <TopBar
+        {...defaultTopBarProps()}
+        agentDefinitions={[{
+          id: 'codex',
+          label: 'Codex',
+          plural_label: 'Codex Sessions',
+          badge: 'CODEX',
+          tmux_socket: 'codex',
+          workspace: 'agent-codex',
+          enabled: true,
+        }]}
+        combinedAgentPane={true}
+      />,
+      { wrapper },
+    );
+    expect(screen.getByText('Agents')).toBeDefined();
+    expect(screen.queryByText('Codex Sessions')).toBeNull();
+  });
+
+  it('shows configured per-agent buttons when combined pane is disabled', () => {
+    render(
+      <TopBar
+        {...defaultTopBarProps()}
+        agentDefinitions={[{
+          id: 'codex',
+          label: 'Codex',
+          plural_label: 'Codex Sessions',
+          badge: 'CODEX',
+          tmux_socket: 'codex',
+          workspace: 'agent-codex',
+          enabled: true,
+        }]}
+        combinedAgentPane={false}
+      />,
+      { wrapper },
+    );
+    expect(screen.queryByText('Agents')).toBeNull();
+    expect(screen.getByText('Codex Sessions')).toBeDefined();
+  });
+
+  it('renders a config-driven host switcher only when enabled', () => {
+    render(
+      <TopBar
+        {...defaultTopBarProps()}
+        hostSwitcher={{
+          enabled: true,
+          suffixes: [],
+          hosts: [
+            { id: 'lab-a', label: 'Lab A', hostname: 'lab-a-webmux.example.net' },
+            { id: 'lab-b', label: 'Lab B', hostname: 'lab-b-webmux.example.net' },
+          ],
+        }}
+      />,
+      { wrapper },
+    );
+    expect(screen.getByTestId('host-switcher')).toBeDefined();
+    expect(screen.getByText('Lab A')).toBeDefined();
+    expect(screen.getByText('Lab B')).toBeDefined();
   });
 });

--- a/tests/frontend/WorkspacePaneContext.test.tsx
+++ b/tests/frontend/WorkspacePaneContext.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { WorkspacePaneProvider, useWorkspacePane } from '@frontend/contexts/WorkspacePaneContext';
 
 function TestConsumer() {
@@ -9,6 +9,7 @@ function TestConsumer() {
       <span data-testid="pane">{activePane}</span>
       <button onClick={() => setActivePane('desktops')}>go desktops</button>
       <button onClick={() => setActivePane('terminals')}>go terminals</button>
+      <button onClick={() => setActivePane('agents')}>go agents</button>
     </div>
   );
 }
@@ -53,5 +54,32 @@ describe('WorkspacePaneContext', () => {
     );
     // Initial render reflects provider default
     expect(screen.getByTestId('pane').textContent).toBe('terminals');
+  });
+
+  it('uses a configured default pane when it is available', () => {
+    render(
+      <WorkspacePaneProvider defaultPane="agents" availablePanes={['terminals', 'desktops', 'agents']}>
+        <TestConsumer />
+      </WorkspacePaneProvider>,
+    );
+    expect(screen.getByTestId('pane').textContent).toBe('agents');
+  });
+
+  it('falls back when the active pane is removed from available panes', async () => {
+    const { rerender } = render(
+      <WorkspacePaneProvider defaultPane="agents" availablePanes={['terminals', 'desktops', 'agents']}>
+        <TestConsumer />
+      </WorkspacePaneProvider>,
+    );
+    expect(screen.getByTestId('pane').textContent).toBe('agents');
+
+    rerender(
+      <WorkspacePaneProvider defaultPane="agents" availablePanes={['terminals', 'desktops']}>
+        <TestConsumer />
+      </WorkspacePaneProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('pane').textContent).toBe('terminals');
+    });
   });
 });

--- a/webmux/README.md
+++ b/webmux/README.md
@@ -18,6 +18,7 @@ A web-native tmux-on-a-jump-box: a persistent shared terminal wall that runs in 
 - **YAML configuration** — human-editable, lift-and-shift deployment
 - **SSH with keepalive** — `ServerAliveInterval`, `ServerAliveCountMax`, `ConnectTimeout`
 - **Audit log** — JSONL append-only event log
+- **Optional agent views** — disabled-by-default tmux-backed agent session browser
 
 ## Quick Start
 
@@ -55,6 +56,8 @@ app:
 ```
 
 `WEBMUX_TERMINAL_GRID_MAX_COLS` and `WEBMUX_TERMINAL_GRID_MAX_ROWS` can override those YAML values at runtime.
+
+Agent views are configured under `app.agents` and are disabled by default. See `../docs/agent-views.md` and `examples/agent-views/app.yaml` for setup, security notes, optional status hooks, and host-switcher examples.
 
 Add hosts to `config/hosts.yaml`:
 
@@ -161,6 +164,10 @@ Passwords are stored as Argon2id hashes. Plain-text passwords are never written 
 | `PUT` | `/api/config` | Update app config |
 | `GET` | `/api/config/layout` | Get layout |
 | `PUT` | `/api/config/layout` | Update layout |
+| `GET` | `/api/agents/config` | Get normalized agent-view config |
+| `GET` | `/api/agents/sessions` | List configured agent tmux sessions |
+| `POST` | `/api/agents/:agentId/attach` | Attach to a validated tmux session |
+| `POST` | `/api/agents/:agentId/scratch` | Open or reuse an agent scratch shell |
 | `WS` | `/api/term/:id?token=<jwt>` | Terminal WebSocket |
 
 ### WebSocket Message Types

--- a/webmux/backend/src/api/agents.ts
+++ b/webmux/backend/src/api/agents.ts
@@ -2,8 +2,7 @@ import { Router, Request, Response, NextFunction } from 'express';
 import { requireAuth, AuthPayload } from '../middleware/auth';
 import { agentService } from '../services/agentService';
 import { sessionBroker } from '../services/sessionBroker';
-import { persistence } from '../services/persistenceManager';
-import type { NormalizedAgentsConfig } from '../types';
+import { getAgentAccess } from '../services/agentAccess';
 
 const router = Router();
 
@@ -20,41 +19,23 @@ function parseTermSize(body: { cols?: unknown; rows?: unknown }) {
   };
 }
 
-function loadAgentRuntimeConfig(): NormalizedAgentsConfig {
-  return agentService.getRuntimeConfig();
-}
-
-function requireAgentAccess(_req: Request, res: Response, next: NextFunction): void {
-  let agentConfig: NormalizedAgentsConfig;
+async function requireAgentAccess(_req: Request, res: Response, next: NextFunction): Promise<void> {
   try {
-    agentConfig = loadAgentRuntimeConfig();
-  } catch (err) {
-    res.status(500).json({ error: (err as Error).message });
-    return;
-  }
-
-  if (!agentConfig.enabled || agentConfig.definitions.length === 0) {
-    res.status(404).json({ error: 'Agent sessions are not enabled' });
-    return;
-  }
-
-  if (!agentConfig.disable_in_multi_user_mode) {
-    next();
-    return;
-  }
-
-  try {
-    const authConfig = persistence.loadAuth();
-    const userCount = authConfig.auth.users?.length ?? 0;
-    if (authConfig.auth.mode === 'none' || userCount <= 1) {
-      next();
+    const access = getAgentAccess();
+    if (!access.allowed) {
+      if (access.status !== 500) {
+        await sessionBroker.deleteAgentSessions(access.error);
+      }
+      res.status(access.status).json({ error: access.error });
       return;
     }
-  } catch (err) {
-    console.error('Agent access check failed:', err);
-  }
 
-  res.status(403).json({ error: 'Agent sessions are disabled in multi-user mode' });
+    await sessionBroker.enforceAgentAccessPolicy();
+    next();
+  } catch (err) {
+    console.error('Agent access cleanup failed:', err);
+    res.status(500).json({ error: 'Failed to enforce agent access policy' });
+  }
 }
 
 function sendInvalidAgent(res: Response): void {
@@ -65,7 +46,7 @@ router.use(requireAuth);
 
 router.get('/config', (_req: Request, res: Response) => {
   try {
-    res.json(loadAgentRuntimeConfig());
+    res.json(agentService.getRuntimeConfig());
   } catch (err) {
     res.status(500).json({ error: (err as Error).message });
   }

--- a/webmux/backend/src/api/agents.ts
+++ b/webmux/backend/src/api/agents.ts
@@ -1,0 +1,164 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { requireAuth, AuthPayload } from '../middleware/auth';
+import { agentService } from '../services/agentService';
+import { sessionBroker } from '../services/sessionBroker';
+import { persistence } from '../services/persistenceManager';
+import type { NormalizedAgentsConfig } from '../types';
+
+const router = Router();
+
+function getOwner(req: Request): string {
+  return (req as Request & { user?: AuthPayload }).user?.sub || 'anonymous';
+}
+
+function parseTermSize(body: { cols?: unknown; rows?: unknown }) {
+  const cols = typeof body.cols === 'number' && Number.isFinite(body.cols) ? body.cols : 120;
+  const rows = typeof body.rows === 'number' && Number.isFinite(body.rows) ? body.rows : 40;
+  return {
+    cols: Math.max(40, Math.min(240, Math.floor(cols))),
+    rows: Math.max(10, Math.min(80, Math.floor(rows))),
+  };
+}
+
+function loadAgentRuntimeConfig(): NormalizedAgentsConfig {
+  return agentService.getRuntimeConfig();
+}
+
+function requireAgentAccess(_req: Request, res: Response, next: NextFunction): void {
+  let agentConfig: NormalizedAgentsConfig;
+  try {
+    agentConfig = loadAgentRuntimeConfig();
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+    return;
+  }
+
+  if (!agentConfig.enabled || agentConfig.definitions.length === 0) {
+    res.status(404).json({ error: 'Agent sessions are not enabled' });
+    return;
+  }
+
+  if (!agentConfig.disable_in_multi_user_mode) {
+    next();
+    return;
+  }
+
+  try {
+    const authConfig = persistence.loadAuth();
+    const userCount = authConfig.auth.users?.length ?? 0;
+    if (authConfig.auth.mode === 'none' || userCount <= 1) {
+      next();
+      return;
+    }
+  } catch (err) {
+    console.error('Agent access check failed:', err);
+  }
+
+  res.status(403).json({ error: 'Agent sessions are disabled in multi-user mode' });
+}
+
+function sendInvalidAgent(res: Response): void {
+  res.status(404).json({ error: 'Agent definition not found' });
+}
+
+router.use(requireAuth);
+
+router.get('/config', (_req: Request, res: Response) => {
+  try {
+    res.json(loadAgentRuntimeConfig());
+  } catch (err) {
+    res.status(500).json({ error: (err as Error).message });
+  }
+});
+
+router.get('/sessions', requireAgentAccess, async (_req: Request, res: Response) => {
+  try {
+    res.json(await agentService.listAllSessions());
+  } catch (err) {
+    console.error('Agent list error:', err);
+    res.status(503).json({ error: 'Failed to list agent sessions' });
+  }
+});
+
+router.get('/:agentId/sessions', requireAgentAccess, async (req: Request, res: Response) => {
+  const config = agentService.getConfig(req.params.agentId);
+  if (!config) {
+    sendInvalidAgent(res);
+    return;
+  }
+
+  try {
+    res.json(await agentService.listSessions(config.id));
+  } catch (err) {
+    console.error(`${config.label} list error:`, err);
+    res.status(503).json({ error: `Failed to list ${config.label} sessions` });
+  }
+});
+
+router.post('/:agentId/attach', requireAgentAccess, async (req: Request, res: Response) => {
+  const config = agentService.getConfig(req.params.agentId);
+  if (!config) {
+    sendInvalidAgent(res);
+    return;
+  }
+
+  try {
+    const { name } = req.body as { name?: string };
+    if (!name || typeof name !== 'string') {
+      res.status(400).json({ error: 'name is required' });
+      return;
+    }
+
+    if (!(await agentService.hasSession(config.id, name))) {
+      res.status(404).json({ error: `${config.label} session not found` });
+      return;
+    }
+
+    const { cols, rows } = parseTermSize(req.body as { cols?: unknown; rows?: unknown });
+    const result = await sessionBroker.ensureAgentAttach(
+      getOwner(req),
+      config.id,
+      config.workspace,
+      name,
+      cols,
+      rows,
+      agentService.buildAttachExecArgv(config.id, name),
+    );
+    res.status(result.created ? 201 : 200).json(result.session);
+  } catch (err) {
+    console.error(`${config.label} attach error:`, err);
+    res.status(500).json({ error: `Failed to attach ${config.label} session` });
+  }
+});
+
+router.post('/:agentId/scratch', requireAgentAccess, async (req: Request, res: Response) => {
+  const config = agentService.getConfig(req.params.agentId);
+  if (!config) {
+    sendInvalidAgent(res);
+    return;
+  }
+
+  try {
+    const { selectedName } = req.body as { selectedName?: string };
+    if (selectedName !== undefined && typeof selectedName !== 'string') {
+      res.status(400).json({ error: 'selectedName must be a string' });
+      return;
+    }
+    const { cols, rows } = parseTermSize(req.body as { cols?: unknown; rows?: unknown });
+    let cwd: string | undefined;
+    if (selectedName) {
+      if (!(await agentService.hasSession(config.id, selectedName))) {
+        res.status(404).json({ error: `${config.label} session not found` });
+        return;
+      }
+      cwd = await agentService.getPaneCurrentPath(config.id, selectedName);
+    }
+    const result = await sessionBroker.ensureAgentScratch(getOwner(req), config.id, config.workspace, cols, rows, cwd);
+    res.status(result.created ? 201 : 200).json(result.session);
+  } catch (err) {
+    console.error(`${config.label} scratch error:`, err);
+    res.status(500).json({ error: `Failed to create ${config.label} scratch shell` });
+  }
+});
+
+export default router;

--- a/webmux/backend/src/api/config.ts
+++ b/webmux/backend/src/api/config.ts
@@ -7,13 +7,14 @@ import {
   isTerminalGridLimitError,
   terminalGridLimitsFromApp,
 } from '../services/terminalGridLimits';
+import { normalizeAppConfig } from '../services/appConfig';
 
 const router = Router();
 router.use(requireAuth);
 
 router.get('/', (_req: Request, res: Response) => {
   try {
-    const app = appConfigWithEffectiveTerminalGridLimits(persistence.loadApp());
+    const app = normalizeAppConfig(appConfigWithEffectiveTerminalGridLimits(persistence.loadApp()));
     const execCommand = process.env.WEBMUX_EXEC_COMMAND;
     if (execCommand) {
       app.app.exec_command = execCommand;
@@ -25,7 +26,7 @@ router.get('/', (_req: Request, res: Response) => {
 });
 
 // Only allow updating safe fields — not listen_host, ports, or secure_mode at runtime
-const MUTABLE_APP_FIELDS = ['name', 'default_term', 'terminal_grid', 'transport'];
+const MUTABLE_APP_FIELDS = ['name', 'default_term', 'terminal_grid', 'transport', 'ui'];
 
 router.put('/', (req: Request, res: Response) => {
   try {
@@ -60,7 +61,7 @@ router.put('/', (req: Request, res: Response) => {
       throw err;
     }
     persistence.saveApp(merged);
-    res.json(appConfigWithEffectiveTerminalGridLimits(merged));
+    res.json(normalizeAppConfig(appConfigWithEffectiveTerminalGridLimits(merged)));
   } catch {
     res.status(500).json({ error: 'Failed to save config' });
   }

--- a/webmux/backend/src/api/sessions.ts
+++ b/webmux/backend/src/api/sessions.ts
@@ -3,6 +3,7 @@ import { sessionBroker } from '../services/sessionBroker';
 import { requireAuth, AuthPayload } from '../middleware/auth';
 import { CreateSessionRequest } from '../types';
 import { isTerminalGridLimitError } from '../services/terminalGridLimits';
+import { AgentAccessError } from '../services/agentAccess';
 
 const router = Router();
 router.use(requireAuth);
@@ -58,6 +59,10 @@ router.post('/:id/reconnect', async (req: Request, res: Response) => {
     const updated = await sessionBroker.reconnect(req.params.id, password);
     res.json(updated);
   } catch (err) {
+    if (err instanceof AgentAccessError) {
+      res.status(err.status).json({ error: err.message });
+      return;
+    }
     console.error('Reconnect error:', err);
     res.status(500).json({ error: 'Failed to reconnect session' });
   }

--- a/webmux/backend/src/index.ts
+++ b/webmux/backend/src/index.ts
@@ -55,6 +55,13 @@ async function main(): Promise<void> {
   await sessionBroker.initialize();
   await vncBroker.initialize();
   await rdpBroker.initialize();
+  const enforceAgentAccessPolicy = (): void => {
+    sessionBroker.enforceAgentAccessPolicy().catch(err => {
+      console.error('Agent access policy enforcement failed:', err);
+    });
+  };
+  persistence.watchConfig('app.yaml', enforceAgentAccessPolicy);
+  persistence.watchConfig('auth.yaml', enforceAgentAccessPolicy);
   startPurgeTimer();
 
   // Slave mode: auto-create an exec session on startup if WEBMUX_SLAVE_HOST is set.

--- a/webmux/backend/src/index.ts
+++ b/webmux/backend/src/index.ts
@@ -17,6 +17,7 @@ import aiRouter from './api/ai';
 import templatesRouter from './api/templates';
 import vncRouter from './api/vnc';
 import rdpRouter from './api/rdp';
+import agentsRouter from './api/agents';
 import { setupWebSocket } from './websocket/handler';
 import { setupVncWebSocket } from './websocket/vncHandler';
 import { setupRdpWebSocket } from './websocket/rdpHandler';
@@ -24,13 +25,14 @@ import { sessionBroker } from './services/sessionBroker';
 import { vncBroker } from './services/vncBroker';
 import { rdpBroker } from './services/rdpBroker';
 import { persistence } from './services/persistenceManager';
+import { normalizeAppConfig } from './services/appConfig';
 
 const WEBMUX_ROOT = process.env.WEBMUX_ROOT || path.join(__dirname, '../..');
 
 async function main(): Promise<void> {
   let appConfig;
   try {
-    appConfig = persistence.loadApp();
+    appConfig = normalizeAppConfig(persistence.loadApp());
   } catch {
     console.warn('Could not load app.yaml, using defaults');
     appConfig = {
@@ -43,6 +45,8 @@ async function main(): Promise<void> {
         trusted_http_allowed: true,
         default_term: { cols: 80, rows: 24, font_size: 14 },
         terminal_grid: { max_cols: null, max_rows: null },
+        ui: { default_pane: 'terminals', host_switcher: { enabled: false, suffixes: [], hosts: [] } },
+        agents: { enabled: false, combined_pane: true, disable_in_multi_user_mode: true, definitions: [] },
         transport: { prefer_mosh: false, ssh_fallback: true, mosh_server_path: '' },
       },
     };
@@ -111,6 +115,7 @@ async function main(): Promise<void> {
   app.use('/api/sessions/templates', templatesRouter);
   app.use('/api/vnc', vncRouter);
   app.use('/api/rdp', rdpRouter);
+  app.use('/api/agents', agentsRouter);
 
   // Health check
   app.get('/api/health', (_req, res) => {

--- a/webmux/backend/src/services/agentAccess.ts
+++ b/webmux/backend/src/services/agentAccess.ts
@@ -1,0 +1,50 @@
+import { agentService } from './agentService';
+import { persistence } from './persistenceManager';
+
+export interface AgentAccessResult {
+  allowed: boolean;
+  status: number;
+  error: string;
+}
+
+export class AgentAccessError extends Error {
+  status: number;
+
+  constructor(result: AgentAccessResult) {
+    super(result.error);
+    this.name = 'AgentAccessError';
+    this.status = result.status;
+  }
+}
+
+export function getAgentAccess(agentId?: string): AgentAccessResult {
+  try {
+    const agentConfig = agentService.getRuntimeConfig();
+
+    if (!agentConfig.enabled || agentConfig.definitions.length === 0) {
+      return { allowed: false, status: 404, error: 'Agent sessions are not enabled' };
+    }
+
+    if (agentId && !agentConfig.definitions.some(definition => definition.id === agentId)) {
+      return { allowed: false, status: 404, error: 'Agent definition not found' };
+    }
+
+    if (!agentConfig.disable_in_multi_user_mode) {
+      return { allowed: true, status: 200, error: '' };
+    }
+
+    try {
+      const authConfig = persistence.loadAuth();
+      const userCount = authConfig.auth.users?.length ?? 0;
+      if (authConfig.auth.mode === 'none' || userCount <= 1) {
+        return { allowed: true, status: 200, error: '' };
+      }
+    } catch (err) {
+      console.error('Agent access check failed:', err);
+    }
+
+    return { allowed: false, status: 403, error: 'Agent sessions are disabled in multi-user mode' };
+  } catch (err) {
+    return { allowed: false, status: 500, error: (err as Error).message };
+  }
+}

--- a/webmux/backend/src/services/agentService.ts
+++ b/webmux/backend/src/services/agentService.ts
@@ -1,0 +1,323 @@
+import { execFile } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import type {
+  AgentDefinition,
+  AgentRuntimeStatus,
+  AgentStatusSource,
+  AgentTmuxSession,
+  NormalizedAgentsConfig,
+} from '../types';
+import { DATA_DIR, persistence } from './persistenceManager';
+import { normalizeAgentsConfig } from './appConfig';
+
+const STATUS_STALE_MS = 24 * 60 * 60 * 1000;
+const STATUS_RECENT_MS = 5 * 60 * 1000;
+const STATUS_ACTIVITY_SLOP_MS = 1500;
+
+interface AgentStatusMetadata {
+  agent_id?: string;
+  name?: string;
+  status?: AgentRuntimeStatus;
+  source?: AgentStatusSource;
+  updated_at?: string;
+  last_input_at?: string;
+  last_output_at?: string;
+  last_output_source?: 'live';
+  last_ready_at?: string;
+}
+
+function isNoTmuxServerError(err: unknown): boolean {
+  const error = err as NodeJS.ErrnoException & { stderr?: string };
+  const text = `${error.message ?? ''}\n${error.stderr ?? ''}`.toLowerCase();
+  return text.includes('no server running') ||
+    (text.includes('error connecting to') && text.includes('no such file or directory'));
+}
+
+function epochSecondsToIso(raw: string | undefined): string | undefined {
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) return undefined;
+  return new Date(value * 1000).toISOString();
+}
+
+function isoTime(value: string | undefined): number {
+  if (!value) return 0;
+  const time = Date.parse(value);
+  return Number.isFinite(time) ? time : 0;
+}
+
+function latestIso(...values: (string | undefined)[]): string | undefined {
+  let latest = 0;
+  let latestValue: string | undefined;
+  for (const value of values) {
+    const time = isoTime(value);
+    if (time > latest) {
+      latest = time;
+      latestValue = value;
+    }
+  }
+  return latestValue;
+}
+
+function metadataLastOutput(metadata: AgentStatusMetadata | undefined): string | undefined {
+  if (metadata?.source === 'webmux' && metadata.last_output_source !== 'live') return undefined;
+  return metadata?.last_output_at;
+}
+
+function statusFileName(name: string): string {
+  return Buffer.from(name, 'utf8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+function statusDir(agentId: string): string {
+  return path.join(DATA_DIR, 'agent-status', agentId);
+}
+
+function statusPath(agentId: string, name: string): string {
+  return path.join(statusDir(agentId), `${statusFileName(name)}.json`);
+}
+
+function normalizeDisplayBase(agentId: string, name: string): string {
+  const withoutPrefix = name.startsWith(`${agentId}-`) ? name.slice(agentId.length + 1) : name;
+  return withoutPrefix.replace(/-\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}$/, '') || name;
+}
+
+export class AgentService {
+  getRuntimeConfig(): NormalizedAgentsConfig {
+    return normalizeAgentsConfig(persistence.loadApp());
+  }
+
+  getDefinitions(): AgentDefinition[] {
+    const config = this.getRuntimeConfig();
+    return config.enabled ? config.definitions : [];
+  }
+
+  getConfig(agentId: string): AgentDefinition | undefined {
+    return this.getDefinitions().find(definition => definition.id === agentId);
+  }
+
+  parseTmuxSessions(output: string, definition: AgentDefinition): AgentTmuxSession[] {
+    const sessions = output
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(Boolean)
+      .map(line => {
+        const [name, windowsRaw, attachedRaw, createdRaw, activityRaw] = line.split('\t');
+        const createdAt = epochSecondsToIso(createdRaw);
+        const activityAt = epochSecondsToIso(activityRaw);
+        return {
+          name,
+          agent_id: definition.id,
+          display_name: normalizeDisplayBase(definition.id, name),
+          windows: Number(windowsRaw) || 0,
+          attached: Number(attachedRaw) || 0,
+          created_at: createdAt,
+          last_output_at: activityAt,
+          status: this.inferStatus(activityAt),
+          status_source: activityAt ? 'tmux' as AgentStatusSource : 'none' as AgentStatusSource,
+        };
+      })
+      .filter(session => session.name.length > 0);
+    return this.assignDisplayNames(sessions);
+  }
+
+  private execFileOutput(command: string, args: string[]): Promise<string> {
+    return new Promise((resolve, reject) => {
+      execFile(command, args, { encoding: 'utf8' }, (err, stdout, stderr) => {
+        if (err) {
+          (err as NodeJS.ErrnoException & { stderr?: string }).stderr = String(stderr ?? '');
+          reject(err);
+          return;
+        }
+        resolve(String(stdout));
+      });
+    });
+  }
+
+  private tmuxSocketArgs(definition: AgentDefinition): string[] {
+    return path.isAbsolute(definition.tmux_socket)
+      ? ['-S', definition.tmux_socket]
+      : ['-L', definition.tmux_socket];
+  }
+
+  private assignDisplayNames(sessions: AgentTmuxSession[]): AgentTmuxSession[] {
+    const byBase = new Map<string, AgentTmuxSession[]>();
+    for (const session of sessions) {
+      const base = normalizeDisplayBase(session.agent_id, session.name);
+      if (!byBase.has(base)) byBase.set(base, []);
+      byBase.get(base)!.push(session);
+      session.display_name = base;
+    }
+
+    for (const [base, group] of byBase) {
+      if (group.length <= 1) continue;
+      const ordered = [...group].sort((a, b) => {
+        const createdDiff = isoTime(a.created_at) - isoTime(b.created_at);
+        return createdDiff || a.agent_id.localeCompare(b.agent_id) || a.name.localeCompare(b.name);
+      });
+      ordered.forEach((session, index) => {
+        session.display_name = `${base} (${index + 1})`;
+      });
+    }
+
+    return sessions;
+  }
+
+  private inferStatus(lastOutputAt: string | undefined, metadata?: AgentStatusMetadata): AgentRuntimeStatus {
+    const now = Date.now();
+    const lastOutputMs = isoTime(lastOutputAt);
+    const metadataUpdatedMs = isoTime(metadata?.updated_at);
+
+    if (metadata?.status === 'waiting') {
+      if (!lastOutputMs || metadataUpdatedMs + STATUS_ACTIVITY_SLOP_MS >= lastOutputMs) {
+        return 'waiting';
+      }
+      return 'working';
+    }
+
+    if (metadata?.status === 'working') return 'working';
+
+    if (lastOutputMs && now - lastOutputMs <= STATUS_RECENT_MS) return 'working';
+    if (!metadata?.status && lastOutputMs && now - lastOutputMs >= STATUS_STALE_MS) return 'stale';
+    return 'unknown';
+  }
+
+  private inferStatusSource(lastOutputAt: string | undefined, metadata?: AgentStatusMetadata): AgentStatusSource {
+    const metadataUpdatedMs = isoTime(metadata?.updated_at);
+    const lastOutputMs = isoTime(lastOutputAt);
+    if (metadata?.status === 'waiting' && (!lastOutputMs || metadataUpdatedMs + STATUS_ACTIVITY_SLOP_MS >= lastOutputMs)) {
+      return metadata.source ?? 'hook';
+    }
+    if (metadata?.status === 'working') return metadata.source ?? 'webmux';
+    return lastOutputAt ? 'tmux' : 'none';
+  }
+
+  private async readStatus(agentId: string, name: string): Promise<AgentStatusMetadata | undefined> {
+    try {
+      const content = await fs.promises.readFile(statusPath(agentId, name), 'utf8');
+      const parsed = JSON.parse(content) as AgentStatusMetadata;
+      if (parsed.agent_id && parsed.agent_id !== agentId) return undefined;
+      if (parsed.name && parsed.name !== name) return undefined;
+      return parsed;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private async mergeStatusMetadata(session: AgentTmuxSession): Promise<AgentTmuxSession> {
+    const metadata = await this.readStatus(session.agent_id, session.name);
+    const lastOutputAt = latestIso(session.last_output_at, metadataLastOutput(metadata), metadata?.last_ready_at);
+    return {
+      ...session,
+      last_output_at: lastOutputAt,
+      status: this.inferStatus(lastOutputAt, metadata),
+      status_source: this.inferStatusSource(lastOutputAt, metadata),
+    };
+  }
+
+  async recordStatus(
+    agentId: string,
+    name: string,
+    update: {
+      status: AgentRuntimeStatus;
+      source: AgentStatusSource;
+      last_input_at?: string;
+      last_output_at?: string;
+      last_output_source?: 'live';
+      last_ready_at?: string;
+    },
+  ): Promise<void> {
+    const updatedAt = new Date().toISOString();
+    const file = statusPath(agentId, name);
+    await fs.promises.mkdir(path.dirname(file), { recursive: true });
+    const previous = await this.readStatus(agentId, name);
+    const lastOutputSource = update.last_output_source ?? (update.last_output_at === undefined ? previous?.last_output_source : undefined);
+    const next: AgentStatusMetadata = {
+      ...previous,
+      agent_id: agentId,
+      name,
+      status: update.status,
+      source: update.source,
+      updated_at: updatedAt,
+      last_input_at: update.last_input_at ?? previous?.last_input_at,
+      last_output_at: update.last_output_at ?? previous?.last_output_at,
+      last_output_source: lastOutputSource,
+      last_ready_at: update.last_ready_at ?? previous?.last_ready_at,
+    };
+    const tmp = `${file}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    await fs.promises.writeFile(tmp, `${JSON.stringify(next, null, 2)}\n`, 'utf8');
+    await fs.promises.rename(tmp, file);
+  }
+
+  async listSessions(agentId: string): Promise<AgentTmuxSession[]> {
+    const definition = this.getConfig(agentId);
+    if (!definition) throw new Error(`Agent '${agentId}' is not configured`);
+
+    try {
+      const output = await this.execFileOutput('tmux', [
+        ...this.tmuxSocketArgs(definition),
+        'list-sessions',
+        '-F',
+        '#S\t#{session_windows}\t#{session_attached}\t#{session_created}\t#{session_activity}',
+      ]);
+      const sessions = this.parseTmuxSessions(output, definition);
+      const enriched = await Promise.all(sessions.map(session => this.mergeStatusMetadata(session)));
+      return this.assignDisplayNames(enriched);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new Error('tmux is not installed');
+      }
+      if (isNoTmuxServerError(err)) return [];
+      throw err;
+    }
+  }
+
+  async listAllSessions(): Promise<AgentTmuxSession[]> {
+    const sessions: AgentTmuxSession[] = [];
+    for (const definition of this.getDefinitions()) {
+      try {
+        sessions.push(...await this.listSessions(definition.id));
+      } catch (err) {
+        console.warn(`Failed to list ${definition.id} sessions for combined agent list:`, err);
+      }
+    }
+    return this.assignDisplayNames(sessions);
+  }
+
+  async hasSession(agentId: string, name: string): Promise<boolean> {
+    return (await this.listSessions(agentId)).some(session => session.name === name);
+  }
+
+  buildAttachExecArgv(agentId: string, name: string): string[] {
+    const definition = this.getConfig(agentId);
+    if (!definition) throw new Error(`Agent '${agentId}' is not configured`);
+    return ['tmux', ...this.tmuxSocketArgs(definition), 'attach-session', '-t', name];
+  }
+
+  async getPaneCurrentPath(agentId: string, name: string): Promise<string | undefined> {
+    const definition = this.getConfig(agentId);
+    if (!definition) return undefined;
+
+    try {
+      const output = await this.execFileOutput('tmux', [
+        ...this.tmuxSocketArgs(definition),
+        'display-message',
+        '-p',
+        '-t',
+        name,
+        '#{pane_current_path}',
+      ]);
+      const cwd = output.trim();
+      if (!cwd || !path.isAbsolute(cwd)) return undefined;
+      const stat = await fs.promises.stat(cwd);
+      return stat.isDirectory() ? cwd : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+}
+
+export const agentService = new AgentService();

--- a/webmux/backend/src/services/appConfig.ts
+++ b/webmux/backend/src/services/appConfig.ts
@@ -1,0 +1,114 @@
+import * as path from 'path';
+import type {
+  AgentDefinition,
+  AgentDefinitionConfig,
+  AppConfig,
+  HostSwitcherConfig,
+  NormalizedAgentsConfig,
+  WorkspaceName,
+} from '../types';
+
+const AGENT_ID_RE = /^[a-z][a-z0-9_-]{0,63}$/;
+const TMUX_SOCKET_RE = /^[a-zA-Z0-9_.-]+$/;
+
+function stringOrDefault(value: unknown, fallback: string): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : fallback;
+}
+
+function booleanOrDefault(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function normalizeWorkspace(value: unknown, id: string): WorkspaceName {
+  const workspace = stringOrDefault(value, `agent-${id}`);
+  if (workspace.includes('\0')) {
+    throw new Error(`Invalid workspace for agent '${id}'`);
+  }
+  return workspace;
+}
+
+function normalizeTmuxSocket(value: unknown, id: string): string {
+  const socket = stringOrDefault(value, '');
+  if (!socket) {
+    throw new Error(`Agent '${id}' requires tmux_socket`);
+  }
+  if (socket.includes('\0')) {
+    throw new Error(`Invalid tmux_socket for agent '${id}'`);
+  }
+  if (path.isAbsolute(socket)) return socket;
+  if (!TMUX_SOCKET_RE.test(socket)) {
+    throw new Error(`Invalid tmux_socket for agent '${id}'`);
+  }
+  return socket;
+}
+
+export function normalizeAgentDefinition(raw: AgentDefinitionConfig): AgentDefinition {
+  const id = stringOrDefault(raw.id, '');
+  if (!AGENT_ID_RE.test(id)) {
+    throw new Error(`Invalid agent id '${raw.id}'`);
+  }
+  const label = stringOrDefault(raw.label, id);
+  const pluralLabel = stringOrDefault(raw.plural_label, `${label} Sessions`);
+  const badge = stringOrDefault(raw.badge, id.toUpperCase()).slice(0, 16);
+  return {
+    id,
+    label,
+    plural_label: pluralLabel,
+    badge,
+    tmux_socket: normalizeTmuxSocket(raw.tmux_socket, id),
+    workspace: normalizeWorkspace(raw.workspace, id),
+    enabled: raw.enabled !== false,
+  };
+}
+
+export function normalizeAgentsConfig(config: AppConfig): NormalizedAgentsConfig {
+  const raw = config.app.agents ?? {};
+  const enabled = booleanOrDefault(raw.enabled, false);
+  const definitions = (enabled ? raw.definitions ?? [] : [])
+    .filter(definition => definition.enabled !== false)
+    .map(normalizeAgentDefinition)
+    .filter(definition => definition.enabled);
+  const seen = new Set<string>();
+  for (const definition of definitions) {
+    if (seen.has(definition.id)) {
+      throw new Error(`Duplicate agent id '${definition.id}'`);
+    }
+    seen.add(definition.id);
+  }
+  return {
+    enabled,
+    combined_pane: booleanOrDefault(raw.combined_pane, true),
+    disable_in_multi_user_mode: booleanOrDefault(raw.disable_in_multi_user_mode, true),
+    definitions,
+  };
+}
+
+function normalizeHostSwitcher(raw: HostSwitcherConfig | undefined): Required<HostSwitcherConfig> {
+  return {
+    enabled: raw?.enabled === true,
+    suffixes: Array.isArray(raw?.suffixes) ? raw!.suffixes.filter(suffix => typeof suffix === 'string' && suffix.trim()) : [],
+    hosts: Array.isArray(raw?.hosts)
+      ? raw!.hosts.filter(host => typeof host?.id === 'string' && typeof host?.hostname === 'string')
+      : [],
+  };
+}
+
+export function normalizeAppConfig(config: AppConfig): AppConfig {
+  const agents = normalizeAgentsConfig(config);
+  const ui = config.app.ui ?? {};
+  return {
+    app: {
+      ...config.app,
+      terminal_grid: {
+        ...config.app.terminal_grid,
+        max_cols: config.app.terminal_grid?.max_cols ?? null,
+        max_rows: config.app.terminal_grid?.max_rows ?? null,
+      },
+      ui: {
+        default_pane: stringOrDefault(ui.default_pane, 'terminals'),
+        host_switcher: normalizeHostSwitcher(ui.host_switcher),
+      },
+      agents,
+    },
+  };
+}

--- a/webmux/backend/src/services/persistenceManager.ts
+++ b/webmux/backend/src/services/persistenceManager.ts
@@ -11,7 +11,7 @@ const WEBMUX_ROOT = process.env.WEBMUX_ROOT || path.join(__dirname, '../../..');
 const WEBMUX_HOME = process.env.WEBMUX_HOME || path.join(os.homedir(), '.config', 'webmux');
 const DEFAULTS_DIR = path.join(WEBMUX_ROOT, 'config.defaults');
 const CONFIG_DIR = path.join(WEBMUX_HOME, 'config');
-const DATA_DIR = path.join(WEBMUX_HOME, 'data');
+export const DATA_DIR = path.join(WEBMUX_HOME, 'data');
 const SESSIONS_DIR = path.join(DATA_DIR, 'sessions');
 const EVENTS_DIR = path.join(DATA_DIR, 'events');
 

--- a/webmux/backend/src/services/presenceService.ts
+++ b/webmux/backend/src/services/presenceService.ts
@@ -126,6 +126,19 @@ export class PresenceService extends EventEmitter {
     });
   }
 
+  closeSession(sessionId: string, code = 1000, reason = 'Session closed'): void {
+    const sv = this.sessionViewers.get(sessionId);
+    if (!sv) return;
+
+    for (const viewerId of Array.from(sv)) {
+      const viewer = this.viewers.get(viewerId);
+      if (viewer?.ws.readyState === WebSocket.OPEN || viewer?.ws.readyState === WebSocket.CONNECTING) {
+        viewer.ws.close(code, reason);
+      }
+      this.leave(viewerId);
+    }
+  }
+
   sendToViewer(viewerId: string, message: Record<string, unknown>): void {
     const viewer = this.viewers.get(viewerId);
     if (viewer?.ws.readyState === WebSocket.OPEN) {

--- a/webmux/backend/src/services/sessionBroker.ts
+++ b/webmux/backend/src/services/sessionBroker.ts
@@ -8,9 +8,10 @@ import { persistence } from './persistenceManager';
 import { compactPositions } from './gridLayout';
 import { assertTerminalGridPosition, nextTerminalGridPosition } from './terminalGridLimits';
 import { agentService } from './agentService';
+import { AgentAccessError, getAgentAccess } from './agentAccess';
 import type { AgentSessionRole, WorkspaceName } from '../types';
 
-function isAgentSession(session?: Session): boolean {
+export function isAgentSession(session?: Session): boolean {
   return !!session?.agent_id && !!session.agent_role;
 }
 
@@ -67,6 +68,11 @@ interface InternalCreateSessionOptions {
   agentSessionName?: string;
 }
 
+interface DeleteSessionOptions {
+  closeCode?: number;
+  closeReason?: string;
+}
+
 export class SessionBroker extends EventEmitter {
   private sessions = new Map<string, Session>();
   private scrollback = new Map<string, string>();
@@ -88,6 +94,7 @@ export class SessionBroker extends EventEmitter {
       this.sessions.set(s.id, s);
     });
     console.log(`Loaded ${saved.length} sessions from persistence`);
+    await this.enforceAgentAccessPolicy();
 
     // Auto-reconnect persistent sessions that were previously active
     const reconnectable = saved.filter(s => s.persistent && s.hostname && !isAgentSession(s));
@@ -316,6 +323,15 @@ export class SessionBroker extends EventEmitter {
   async reconnect(sessionId: string, password?: string): Promise<Session> {
     const session = this.sessions.get(sessionId);
     if (!session) throw new Error(`Session ${sessionId} not found`);
+    if (isAgentSession(session)) {
+      const access = getAgentAccess(session.agent_id);
+      if (!access.allowed) {
+        if (access.status !== 500) {
+          await this.delete(sessionId, { closeCode: 1008, closeReason: access.error });
+        }
+        throw new AgentAccessError(access);
+      }
+    }
 
     if (transportLauncher.isAlive(sessionId)) {
       this.bumpLaunchGeneration(sessionId);
@@ -344,11 +360,12 @@ export class SessionBroker extends EventEmitter {
     return this.scrollback.get(sessionId) || '';
   }
 
-  async delete(sessionId: string): Promise<void> {
+  async delete(sessionId: string, options: DeleteSessionOptions = {}): Promise<void> {
     const session = this.sessions.get(sessionId);
     const owner = session?.owner;
     const wasAgentSession = isAgentSession(session);
     this.bumpLaunchGeneration(sessionId);
+    presenceService.closeSession(sessionId, options.closeCode ?? 1000, options.closeReason ?? 'Session deleted');
     transportLauncher.kill(sessionId);
     this.sessions.delete(sessionId);
     this.launchGenerations.delete(sessionId);
@@ -382,6 +399,23 @@ export class SessionBroker extends EventEmitter {
     });
   }
 
+  async deleteAgentSessions(reason = 'Agent sessions are no longer allowed'): Promise<void> {
+    const sessions = Array.from(this.sessions.values()).filter(isAgentSession);
+    for (const session of sessions) {
+      await this.delete(session.id, { closeCode: 1008, closeReason: reason });
+    }
+  }
+
+  async enforceAgentAccessPolicy(): Promise<void> {
+    const sessions = Array.from(this.sessions.values()).filter(isAgentSession);
+    for (const session of sessions) {
+      const access = getAgentAccess(session.agent_id);
+      if (!access.allowed && access.status !== 500) {
+        await this.delete(session.id, { closeCode: 1008, closeReason: access.error });
+      }
+    }
+  }
+
   findAgentAttach(owner: string, agentId: string, name?: string): Session | undefined {
     const attachSessions = this.listAgentByOwner(owner, agentId).filter(s => s.agent_role === 'attach');
     if (name) {
@@ -408,14 +442,16 @@ export class SessionBroker extends EventEmitter {
     if (existing) {
       const shouldRelaunch = existing.agent_session_name !== name;
       const shouldResize = existing.cols !== cols || existing.rows !== rows;
+      const commandChanged = !argvEqual(existing.exec_argv, execArgv);
       const metadataChanged =
         existing.title !== name ||
         existing.workspace !== workspace ||
-        !argvEqual(existing.exec_argv, execArgv) ||
+        commandChanged ||
         existing.agent_id !== agentId ||
         existing.agent_role !== 'attach' ||
         existing.agent_session_name !== name;
-      const needsRelaunch = shouldRelaunch || !transportLauncher.isAlive(existing.id) || existing.state === 'disconnected' || existing.state === 'error';
+      const needsRelaunch = shouldRelaunch || commandChanged || !transportLauncher.isAlive(existing.id) ||
+        existing.state === 'disconnected' || existing.state === 'error';
       for (const stale of attachSessions) {
         if (stale.id !== existing.id) {
           await this.delete(stale.id);

--- a/webmux/backend/src/services/sessionBroker.ts
+++ b/webmux/backend/src/services/sessionBroker.ts
@@ -7,11 +7,76 @@ import { presenceService } from './presenceService';
 import { persistence } from './persistenceManager';
 import { compactPositions } from './gridLayout';
 import { assertTerminalGridPosition, nextTerminalGridPosition } from './terminalGridLimits';
+import { agentService } from './agentService';
+import type { AgentSessionRole, WorkspaceName } from '../types';
+
+function isAgentSession(session?: Session): boolean {
+  return !!session?.agent_id && !!session.agent_role;
+}
+
+function argvEqual(left: string[] | undefined, right: string[] | undefined): boolean {
+  if (left === right) return true;
+  if (!left || !right || left.length !== right.length) return false;
+  return left.every((value, index) => value === right[index]);
+}
+
+function latestIso(left: string | undefined, right: string | undefined): string | undefined {
+  if (!left) return right;
+  if (!right) return left;
+  return Date.parse(right) >= Date.parse(left) ? right : left;
+}
+
+interface AgentStatusUpdate {
+  status: 'working';
+  source: 'webmux';
+  last_input_at?: string;
+  last_output_at?: string;
+  last_output_source?: 'live';
+}
+
+interface PendingAgentStatusUpdate {
+  agentId: string;
+  name: string;
+  update: AgentStatusUpdate;
+}
+
+function agentStatusKey(agentId: string, name: string): string {
+  return `${agentId}:${name}`;
+}
+
+function mergeAgentStatusUpdates(current: AgentStatusUpdate, next: AgentStatusUpdate): AgentStatusUpdate {
+  const lastOutputAt = latestIso(current.last_output_at, next.last_output_at);
+  const nextOutputIsLatest = !!next.last_output_at && lastOutputAt === next.last_output_at;
+  return {
+    status: next.status,
+    source: next.source,
+    last_input_at: latestIso(current.last_input_at, next.last_input_at),
+    last_output_at: lastOutputAt,
+    last_output_source: nextOutputIsLatest ? next.last_output_source : current.last_output_source,
+  };
+}
+
+interface InternalCreateSessionOptions {
+  title?: string;
+  persistent?: boolean;
+  execArgv?: string[];
+  execCwd?: string;
+  workspace?: WorkspaceName;
+  agentId?: string;
+  agentRole?: AgentSessionRole;
+  agentSessionName?: string;
+}
 
 export class SessionBroker extends EventEmitter {
   private sessions = new Map<string, Session>();
   private scrollback = new Map<string, string>();
+  private launchGenerations = new Map<string, number>();
+  private pendingAgentStatusUpdates = new Map<string, PendingAgentStatusUpdate>();
+  private agentStatusFlushTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private agentStatusWrites = new Map<string, Promise<void>>();
   private static readonly SCROLLBACK_SIZE = 64 * 1024;
+  private static AGENT_ATTACH_REPLAY_SUPPRESS_MS = 1500;
+  private static AGENT_STATUS_FLUSH_DEBOUNCE_MS = 200;
 
   constructor() {
     super();
@@ -25,7 +90,7 @@ export class SessionBroker extends EventEmitter {
     console.log(`Loaded ${saved.length} sessions from persistence`);
 
     // Auto-reconnect persistent sessions that were previously active
-    const reconnectable = saved.filter(s => s.persistent && s.hostname);
+    const reconnectable = saved.filter(s => s.persistent && s.hostname && !isAgentSession(s));
     if (reconnectable.length > 0) {
       console.log(`Auto-reconnecting ${reconnectable.length} persistent sessions...`);
       for (const session of reconnectable) {
@@ -33,8 +98,9 @@ export class SessionBroker extends EventEmitter {
           session.state = 'connecting';
           session.updated_at = new Date().toISOString();
           this.scrollback.delete(session.id);
+          const generation = this.bumpLaunchGeneration(session.id);
           const ptyProcess = transportLauncher.launch(session, undefined, session.key_id || undefined);
-          this.wireEvents(session, ptyProcess);
+          this.wireEvents(session, ptyProcess, undefined, generation);
           console.log(`  reconnected: ${session.title} (${session.id})`);
         } catch (err) {
           session.state = 'error';
@@ -53,12 +119,13 @@ export class SessionBroker extends EventEmitter {
         session.state = 'disconnected';
         session.updated_at = new Date().toISOString();
       }
+      this.bumpLaunchGeneration(session.id);
       transportLauncher.kill(session.id);
     }
     this.persistSessions();
   }
 
-  async create(req: CreateSessionRequest, owner: string = 'anonymous'): Promise<Session> {
+  async create(req: CreateSessionRequest, owner: string = 'anonymous', internal: InternalCreateSessionOptions = {}): Promise<Session> {
     const id = uuidv4();
 
     // Determine hostname
@@ -78,8 +145,10 @@ export class SessionBroker extends EventEmitter {
     }
 
     // Determine layout position (scoped to this owner's sessions)
-    const ownerSessions = Array.from(this.sessions.values()).filter(s => s.owner === owner);
-    const { row, col } = nextTerminalGridPosition(ownerSessions, req.row, req.col);
+    const ownerSessions = Array.from(this.sessions.values()).filter(s => s.owner === owner && !isAgentSession(s));
+    const { row, col } = internal.agentId
+      ? { row: req.row ?? 0, col: req.col ?? 0 }
+      : nextTerminalGridPosition(ownerSessions, req.row, req.col);
 
     // Determine transport: use mosh if host allows it and config prefers it
     let transport = req.transport || 'ssh';
@@ -107,6 +176,8 @@ export class SessionBroker extends EventEmitter {
       username: req.username,
       key_id: req.key_id || '',
       exec_command: req.exec_command,
+      exec_argv: internal.execArgv,
+      exec_cwd: internal.execCwd,
       cols: req.cols || 80,
       rows: req.rows || 24,
       row,
@@ -114,15 +185,20 @@ export class SessionBroker extends EventEmitter {
       state: 'connecting',
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
-      title: transport === 'exec' ? `${hostname}:${port}` : `${req.username}@${hostname}`,
-      persistent: true,
+      title: internal.title ?? (transport === 'exec' ? `${hostname}:${port}` : `${req.username}@${hostname}`),
+      persistent: internal.persistent ?? true,
       minimized: false,
+      workspace: internal.workspace,
+      agent_id: internal.agentId,
+      agent_role: internal.agentRole,
+      agent_session_name: internal.agentSessionName,
     };
 
     this.sessions.set(id, session);
 
     // Launch the PTY process (state stays 'connecting' until first data arrives)
     try {
+      const generation = this.bumpLaunchGeneration(session.id);
       const ptyProcess = transportLauncher.launch(session, req.password, req.key_id);
       // Resolve initial command: explicit > template lookup
       let initialCmd = req.initial_cmd;
@@ -132,7 +208,8 @@ export class SessionBroker extends EventEmitter {
         const tpl = TEMPLATES.find(t => t.id === req.template_id);
         if (tpl?.initialCmd) initialCmd = tpl.initialCmd;
       }
-      this.wireEvents(session, ptyProcess, initialCmd);
+      this.wireEvents(session, ptyProcess, initialCmd, generation);
+      this.markAgentAttachReady(session);
     } catch (err) {
       session.state = 'error';
       session.updated_at = new Date().toISOString();
@@ -145,28 +222,58 @@ export class SessionBroker extends EventEmitter {
     return session;
   }
 
-  private wireEvents(session: Session, ptyProcess: pty.IPty, initialCmd?: string): void {
+  private bumpLaunchGeneration(sessionId: string): number {
+    const next = (this.launchGenerations.get(sessionId) ?? 0) + 1;
+    this.launchGenerations.set(sessionId, next);
+    return next;
+  }
+
+  private isCurrentLaunch(sessionId: string, generation: number): boolean {
+    return this.launchGenerations.get(sessionId) === generation && this.sessions.has(sessionId);
+  }
+
+  private markConnected(session: Session, broadcast = false): boolean {
+    const changed = session.state !== 'connected';
+    if (changed) {
+      session.state = 'connected';
+      session.updated_at = new Date().toISOString();
+    }
+    if (broadcast) {
+      presenceService.broadcastToSession(session.id, {
+        type: 'status',
+        session_id: session.id,
+        state: 'connected',
+      });
+    }
+    return changed;
+  }
+
+  private markAgentAttachReady(session: Session, broadcast = false): boolean {
+    if (session.agent_role !== 'attach') return false;
+    return this.markConnected(session, broadcast);
+  }
+
+  private wireEvents(session: Session, ptyProcess: pty.IPty, initialCmd: string | undefined, generation: number): void {
     let firstData = true;
     let cmdInjected = false;
+    const suppressAgentOutputUntil = session.agent_role === 'attach'
+      ? Date.now() + SessionBroker.AGENT_ATTACH_REPLAY_SUPPRESS_MS
+      : 0;
 
     ptyProcess.onData((data: string) => {
+      if (!this.isCurrentLaunch(session.id, generation)) return;
       if (firstData) {
         firstData = false;
-        session.state = 'connected';
-        session.updated_at = new Date().toISOString();
+        this.markConnected(session, true);
         // Inject initial command after a brief delay so the shell prompt is ready
         if (initialCmd && !cmdInjected) {
           cmdInjected = true;
           setTimeout(() => {
+            if (!this.isCurrentLaunch(session.id, generation)) return;
             try { ptyProcess.write(`${initialCmd}\r`); }
             catch { /* session may have closed */ }
           }, 800);
         }
-        presenceService.broadcastToSession(session.id, {
-          type: 'status',
-          session_id: session.id,
-          state: 'connected',
-        });
         this.persistSessions();
       }
 
@@ -188,9 +295,11 @@ export class SessionBroker extends EventEmitter {
         session_id: session.id,
         data,
       });
+      this.recordAgentActivity(session, 'output', Date.now() < suppressAgentOutputUntil);
     });
 
     ptyProcess.onExit(({ exitCode }: { exitCode: number }) => {
+      if (!this.isCurrentLaunch(session.id, generation)) return;
       session.state = 'disconnected';
       session.updated_at = new Date().toISOString();
       presenceService.broadcastToSession(session.id, {
@@ -209,6 +318,7 @@ export class SessionBroker extends EventEmitter {
     if (!session) throw new Error(`Session ${sessionId} not found`);
 
     if (transportLauncher.isAlive(sessionId)) {
+      this.bumpLaunchGeneration(sessionId);
       transportLauncher.kill(sessionId);
     }
 
@@ -217,8 +327,9 @@ export class SessionBroker extends EventEmitter {
 
     try {
       this.scrollback.delete(session.id);
+      const generation = this.bumpLaunchGeneration(session.id);
       const ptyProcess = transportLauncher.launch(session, password, session.key_id || undefined);
-      this.wireEvents(session, ptyProcess);
+      this.wireEvents(session, ptyProcess, undefined, generation);
     } catch (err) {
       session.state = 'error';
       session.updated_at = new Date().toISOString();
@@ -236,11 +347,14 @@ export class SessionBroker extends EventEmitter {
   async delete(sessionId: string): Promise<void> {
     const session = this.sessions.get(sessionId);
     const owner = session?.owner;
+    const wasAgentSession = isAgentSession(session);
+    this.bumpLaunchGeneration(sessionId);
     transportLauncher.kill(sessionId);
     this.sessions.delete(sessionId);
+    this.launchGenerations.delete(sessionId);
     this.scrollback.delete(sessionId);
-    if (owner) {
-      const ownerSessions = Array.from(this.sessions.values()).filter(s => s.owner === owner);
+    if (owner && !wasAgentSession) {
+      const ownerSessions = Array.from(this.sessions.values()).filter(s => s.owner === owner && !isAgentSession(s));
       compactPositions(ownerSessions);
     }
     this.persistSessions();
@@ -258,12 +372,175 @@ export class SessionBroker extends EventEmitter {
   }
 
   listByOwner(owner: string): Session[] {
-    return Array.from(this.sessions.values()).filter(s => s.owner === owner);
+    return Array.from(this.sessions.values()).filter(s => s.owner === owner && !isAgentSession(s));
+  }
+
+  listAgentByOwner(owner: string, agentId?: string): Session[] {
+    return Array.from(this.sessions.values()).filter(s => {
+      if (s.owner !== owner || !isAgentSession(s)) return false;
+      return !agentId || s.agent_id === agentId;
+    });
+  }
+
+  findAgentAttach(owner: string, agentId: string, name?: string): Session | undefined {
+    const attachSessions = this.listAgentByOwner(owner, agentId).filter(s => s.agent_role === 'attach');
+    if (name) {
+      return attachSessions.find(s => s.agent_session_name === name) ?? attachSessions[0];
+    }
+    return attachSessions[0];
+  }
+
+  findAgentScratch(owner: string, agentId: string): Session | undefined {
+    return this.listAgentByOwner(owner, agentId).find(s => s.agent_role === 'scratch');
+  }
+
+  async ensureAgentAttach(
+    owner: string,
+    agentId: string,
+    workspace: WorkspaceName,
+    name: string,
+    cols: number,
+    rows: number,
+    execArgv: string[],
+  ): Promise<{ session: Session; created: boolean }> {
+    const attachSessions = this.listAgentByOwner(owner, agentId).filter(s => s.agent_role === 'attach');
+    const existing = attachSessions.find(s => s.agent_session_name === name) ?? attachSessions[0];
+    if (existing) {
+      const shouldRelaunch = existing.agent_session_name !== name;
+      const shouldResize = existing.cols !== cols || existing.rows !== rows;
+      const metadataChanged =
+        existing.title !== name ||
+        existing.workspace !== workspace ||
+        !argvEqual(existing.exec_argv, execArgv) ||
+        existing.agent_id !== agentId ||
+        existing.agent_role !== 'attach' ||
+        existing.agent_session_name !== name;
+      const needsRelaunch = shouldRelaunch || !transportLauncher.isAlive(existing.id) || existing.state === 'disconnected' || existing.state === 'error';
+      for (const stale of attachSessions) {
+        if (stale.id !== existing.id) {
+          await this.delete(stale.id);
+        }
+      }
+      if (!needsRelaunch && !shouldResize && !metadataChanged) {
+        if (this.markAgentAttachReady(existing, true)) {
+          this.persistSessions();
+        }
+        return { session: existing, created: false };
+      }
+      existing.cols = cols;
+      existing.rows = rows;
+      existing.title = name;
+      existing.workspace = workspace;
+      existing.exec_argv = execArgv;
+      existing.agent_id = agentId;
+      existing.agent_role = 'attach';
+      existing.agent_session_name = name;
+      existing.updated_at = new Date().toISOString();
+      if (needsRelaunch) {
+        this.relaunch(existing);
+      } else if (shouldResize) {
+        transportLauncher.resize(existing.id, cols, rows);
+        this.markAgentAttachReady(existing, true);
+      } else {
+        this.markAgentAttachReady(existing, true);
+      }
+      this.persistSessions();
+      return { session: existing, created: false };
+    }
+
+    const session = await this.create({
+      username: agentId,
+      hostname: `${agentId}.local`,
+      port: 0,
+      transport: 'exec',
+      cols,
+      rows,
+      row: 0,
+      col: 0,
+    }, owner, {
+      title: name,
+      persistent: false,
+      execArgv,
+      workspace,
+      agentId,
+      agentRole: 'attach',
+      agentSessionName: name,
+    });
+    return { session, created: true };
+  }
+
+  async ensureAgentScratch(
+    owner: string,
+    agentId: string,
+    workspace: WorkspaceName,
+    cols: number,
+    rows: number,
+    cwd?: string,
+  ): Promise<{ session: Session; created: boolean }> {
+    const shell = process.env.SHELL?.trim() || '/bin/sh';
+    const execArgv = [shell, '-l'];
+    const existing = this.findAgentScratch(owner, agentId);
+    if (existing) {
+      existing.cols = cols;
+      existing.rows = rows;
+      existing.workspace = workspace;
+      existing.exec_argv = execArgv;
+      existing.exec_cwd = cwd;
+      existing.agent_id = agentId;
+      existing.agent_role = 'scratch';
+      existing.agent_session_name = undefined;
+      existing.updated_at = new Date().toISOString();
+      if (!transportLauncher.isAlive(existing.id) || existing.state === 'disconnected' || existing.state === 'error') {
+        this.relaunch(existing);
+      } else {
+        transportLauncher.resize(existing.id, cols, rows);
+      }
+      this.persistSessions();
+      return { session: existing, created: false };
+    }
+
+    const session = await this.create({
+      username: 'shell',
+      hostname: 'local.shell',
+      port: 0,
+      transport: 'exec',
+      cols,
+      rows,
+      row: 0,
+      col: 1,
+    }, owner, {
+      title: 'Scratch shell',
+      persistent: false,
+      execArgv,
+      execCwd: cwd,
+      workspace,
+      agentId,
+      agentRole: 'scratch',
+    });
+    return { session, created: true };
+  }
+
+  private relaunch(session: Session): void {
+    const generation = this.bumpLaunchGeneration(session.id);
+    transportLauncher.kill(session.id);
+    session.state = 'connecting';
+    session.updated_at = new Date().toISOString();
+    this.scrollback.delete(session.id);
+    try {
+      const ptyProcess = transportLauncher.launch(session, undefined, session.key_id || undefined);
+      this.wireEvents(session, ptyProcess, undefined, generation);
+      this.markAgentAttachReady(session, true);
+    } catch (err) {
+      session.state = 'error';
+      session.updated_at = new Date().toISOString();
+      throw err;
+    }
   }
 
   move(sessionId: string, row: number, col: number): Session {
     const session = this.sessions.get(sessionId);
     if (!session) throw new Error(`Session ${sessionId} not found`);
+    if (isAgentSession(session)) throw new Error('Agent workspace sessions cannot be moved');
     assertTerminalGridPosition(row, col);
     session.row = row;
     session.col = col;
@@ -303,7 +580,61 @@ export class SessionBroker extends EventEmitter {
     const handle = transportLauncher.getHandle(sessionId);
     if (handle) {
       handle.write(data);
+      const session = this.sessions.get(sessionId);
+      if (session) this.recordAgentActivity(session, 'input');
     }
+  }
+
+  private recordAgentActivity(session: Session, activity: 'input' | 'output', replayOutput = false): void {
+    const agentId = session.agent_id;
+    const name = session.agent_session_name;
+    if (!agentId || session.agent_role !== 'attach' || !name) return;
+    if (activity === 'output' && replayOutput) return;
+
+    const now = new Date().toISOString();
+    const update = activity === 'input'
+      ? { status: 'working' as const, source: 'webmux' as const, last_input_at: now }
+      : { status: 'working' as const, source: 'webmux' as const, last_output_at: now, last_output_source: 'live' as const };
+    this.queueAgentStatusUpdate(agentId, name, update);
+  }
+
+  private queueAgentStatusUpdate(agentId: string, name: string, update: AgentStatusUpdate): void {
+    const key = agentStatusKey(agentId, name);
+    const pending = this.pendingAgentStatusUpdates.get(key);
+    this.pendingAgentStatusUpdates.set(key, pending
+      ? { ...pending, update: mergeAgentStatusUpdates(pending.update, update) }
+      : { agentId, name, update });
+
+    const existingTimer = this.agentStatusFlushTimers.get(key);
+    if (existingTimer) clearTimeout(existingTimer);
+
+    const timer = setTimeout(() => this.flushAgentStatusUpdate(key), SessionBroker.AGENT_STATUS_FLUSH_DEBOUNCE_MS);
+    this.agentStatusFlushTimers.set(key, timer);
+  }
+
+  private flushAgentStatusUpdate(key: string): void {
+    const timer = this.agentStatusFlushTimers.get(key);
+    if (timer) {
+      clearTimeout(timer);
+      this.agentStatusFlushTimers.delete(key);
+    }
+
+    const pending = this.pendingAgentStatusUpdates.get(key);
+    if (!pending) return;
+    this.pendingAgentStatusUpdates.delete(key);
+
+    const previousWrite = this.agentStatusWrites.get(key) ?? Promise.resolve();
+    let write: Promise<void>;
+    write = previousWrite
+      .catch(() => undefined)
+      .then(() => agentService.recordStatus(pending.agentId, pending.name, pending.update))
+      .catch(err => console.error(`Failed to record ${pending.agentId} agent status:`, err))
+      .finally(() => {
+        if (this.agentStatusWrites.get(key) === write) {
+          this.agentStatusWrites.delete(key);
+        }
+      });
+    this.agentStatusWrites.set(key, write);
   }
 
   private persistSessions(): void {
@@ -312,7 +643,7 @@ export class SessionBroker extends EventEmitter {
 
     try {
       const layout = persistence.loadLayout();
-      layout.layout.tiles = sessions.map(s => ({
+      layout.layout.tiles = sessions.filter(s => !isAgentSession(s)).map(s => ({
         session_id: s.id,
         row: s.row,
         col: s.col,

--- a/webmux/backend/src/services/transportLauncher.ts
+++ b/webmux/backend/src/services/transportLauncher.ts
@@ -73,6 +73,27 @@ export class TransportLauncher {
   }
 
   private launchExec(session: Session): pty.IPty {
+    if (session.exec_argv && session.exec_argv.length > 0) {
+      const [command, ...args] = session.exec_argv;
+      if (!command || command.includes('\0')) {
+        throw new Error('Invalid exec argv command');
+      }
+      if (args.some(arg => arg.includes('\0'))) {
+        throw new Error('Invalid exec argv argument');
+      }
+
+      const ptyProcess = pty.spawn(command, args, {
+        name: 'xterm-256color',
+        cols: session.cols,
+        rows: session.rows,
+        cwd: session.exec_cwd || process.env.HOME || '/',
+        env: { ...process.env, TERM: 'xterm-256color' },
+      });
+
+      this.handles.set(session.id, ptyProcess);
+      return ptyProcess;
+    }
+
     const template = session.exec_command || process.env.WEBMUX_EXEC_COMMAND || '';
     if (!template) {
       throw new Error('exec transport requires exec_command or WEBMUX_EXEC_COMMAND env var');
@@ -86,7 +107,7 @@ export class TransportLauncher {
       name: 'xterm-256color',
       cols: session.cols,
       rows: session.rows,
-      cwd: process.env.HOME || '/',
+      cwd: session.exec_cwd || process.env.HOME || '/',
       env: { ...process.env, TERM: 'xterm-256color' },
     });
 

--- a/webmux/backend/src/types/index.ts
+++ b/webmux/backend/src/types/index.ts
@@ -24,9 +24,60 @@ export interface AppConfig {
       host: string;
       port: number;
     };
+    ui?: {
+      default_pane?: WorkspaceName;
+      host_switcher?: HostSwitcherConfig;
+    };
+    agents?: AgentsConfig;
     // Populated from WEBMUX_EXEC_COMMAND env var at runtime; not persisted to app.yaml.
     exec_command?: string;
   };
+}
+
+export interface HostSwitcherConfig {
+  enabled?: boolean;
+  suffixes?: string[];
+  hosts?: HostSwitcherHost[];
+}
+
+export interface HostSwitcherHost {
+  id: string;
+  label?: string;
+  hostname: string;
+}
+
+export interface AgentsConfig {
+  enabled?: boolean;
+  combined_pane?: boolean;
+  disable_in_multi_user_mode?: boolean;
+  definitions?: AgentDefinitionConfig[];
+}
+
+export interface AgentDefinitionConfig {
+  id: string;
+  label: string;
+  plural_label?: string;
+  badge?: string;
+  tmux_socket: string;
+  workspace?: WorkspaceName;
+  enabled?: boolean;
+}
+
+export interface NormalizedAgentsConfig {
+  enabled: boolean;
+  combined_pane: boolean;
+  disable_in_multi_user_mode: boolean;
+  definitions: AgentDefinition[];
+}
+
+export interface AgentDefinition {
+  id: string;
+  label: string;
+  plural_label: string;
+  badge: string;
+  tmux_socket: string;
+  workspace: WorkspaceName;
+  enabled: boolean;
 }
 
 export interface AuthUser {
@@ -46,6 +97,10 @@ export interface AuthConfig {
 export type TransportType = 'ssh' | 'mosh' | 'exec';
 export type SessionKind = 'terminal' | 'vnc' | 'rdp';
 export type ConnectionState = 'connecting' | 'connected' | 'disconnected' | 'error';
+export type WorkspaceName = 'terminals' | 'desktops' | 'agents' | string;
+export type AgentSessionRole = 'attach' | 'scratch';
+export type AgentRuntimeStatus = 'waiting' | 'working' | 'unknown' | 'stale';
+export type AgentStatusSource = 'hook' | 'tmux' | 'webmux' | 'none';
 
 export interface HostEntry {
   id: string;
@@ -102,6 +157,8 @@ export interface Session {
   username: string;
   key_id: string;
   exec_command?: string;
+  exec_argv?: string[];
+  exec_cwd?: string;
   cols: number;
   rows: number;
   row: number;
@@ -112,6 +169,22 @@ export interface Session {
   title: string;
   persistent: boolean;
   minimized: boolean;
+  workspace?: WorkspaceName;
+  agent_id?: string;
+  agent_role?: AgentSessionRole;
+  agent_session_name?: string;
+}
+
+export interface AgentTmuxSession {
+  name: string;
+  agent_id: string;
+  display_name: string;
+  windows: number;
+  attached: number;
+  created_at?: string;
+  last_output_at?: string;
+  status: AgentRuntimeStatus;
+  status_source: AgentStatusSource;
 }
 
 export interface Viewer {

--- a/webmux/backend/src/websocket/handler.ts
+++ b/webmux/backend/src/websocket/handler.ts
@@ -1,11 +1,12 @@
 import WebSocket, { WebSocketServer } from 'ws';
 import { IncomingMessage } from 'http';
 import { v4 as uuidv4 } from 'uuid';
-import { sessionBroker } from '../services/sessionBroker';
+import { isAgentSession, sessionBroker } from '../services/sessionBroker';
 import { presenceService } from '../services/presenceService';
 import { requireAuthWs } from '../middleware/auth';
 import { consumeTicket } from '../api/auth';
 import { WebSocketMessage } from '../types';
+import { getAgentAccess } from '../services/agentAccess';
 
 export function setupWebSocket(wss: WebSocketServer): void {
   wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
@@ -44,6 +45,19 @@ export function setupWebSocket(wss: WebSocketServer): void {
       ws.send(JSON.stringify({ type: 'error', message: 'Session not found' }));
       ws.close(1008, 'Session not found');
       return;
+    }
+    if (isAgentSession(session)) {
+      const access = getAgentAccess(session.agent_id);
+      if (!access.allowed) {
+        ws.send(JSON.stringify({ type: 'error', message: access.error }));
+        ws.close(1008, access.error);
+        if (access.status !== 500) {
+          sessionBroker.delete(session.id, { closeCode: 1008, closeReason: access.error }).catch(err => {
+            console.error(`Failed to delete denied agent session ${session.id}:`, err);
+          });
+        }
+        return;
+      }
     }
 
     presenceService.join(viewerId, sessionId, ws);

--- a/webmux/config.defaults/app.yaml
+++ b/webmux/config.defaults/app.yaml
@@ -12,6 +12,17 @@ app:
   terminal_grid:
     max_cols: null
     max_rows: null
+  ui:
+    default_pane: terminals
+    host_switcher:
+      enabled: false
+      suffixes: []
+      hosts: []
+  agents:
+    enabled: false
+    combined_pane: true
+    disable_in_multi_user_mode: true
+    definitions: []
   transport:
     prefer_mosh: false
     ssh_fallback: true

--- a/webmux/examples/agent-views/app.yaml
+++ b/webmux/examples/agent-views/app.yaml
@@ -1,0 +1,55 @@
+app:
+  name: webmux
+  listen_host: 0.0.0.0
+  http_port: 8080
+  https_port: 8443
+  secure_mode: false
+  trusted_http_allowed: true
+  default_term:
+    cols: 120
+    rows: 40
+    font_size: 14
+  terminal_grid:
+    max_cols: null
+    max_rows: null
+  ui:
+    default_pane: terminals
+    host_switcher:
+      enabled: true
+      suffixes:
+        - example.net
+      hosts:
+        - id: lab-a
+          label: Lab A
+          hostname: lab-a-webmux.example.net
+        - id: lab-b
+          label: Lab B
+          hostname: lab-b-webmux.example.net
+        - id: gpu-box
+          label: GPU Box
+          hostname: gpu-box-webmux.example.net
+        - id: workstation
+          label: Workstation
+          hostname: workstation-webmux.example.net
+  agents:
+    enabled: true
+    combined_pane: true
+    disable_in_multi_user_mode: true
+    definitions:
+      - id: codex
+        label: Codex
+        plural_label: Codex Sessions
+        badge: CODEX
+        tmux_socket: codex
+      - id: helper
+        label: Helper
+        plural_label: Helper Sessions
+        badge: HELP
+        tmux_socket: helper
+  transport:
+    prefer_mosh: false
+    ssh_fallback: true
+    mosh_server_path: ""
+  guacd:
+    host: 127.0.0.1
+    port: 4822

--- a/webmux/frontend/package.json
+++ b/webmux/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint src --ext .ts,.tsx",
-    "test": "NODE_OPTIONS='--localstorage-file=/tmp/webmux-vitest-ls.json' vitest run"
+    "test": "NODE_OPTIONS='--localstorage-file=/tmp/webmux-vitest-ls.json' vitest run --no-file-parallelism"
   },
   "dependencies": {
     "@novnc/novnc": "^1.6.0",

--- a/webmux/frontend/src/App.tsx
+++ b/webmux/frontend/src/App.tsx
@@ -5,11 +5,12 @@ import { LoginPage } from './components/LoginPage';
 import { TopBar } from './components/TopBar';
 import { Workspace } from './components/Workspace';
 import { GraphicsWorkspace } from './components/GraphicsWorkspace';
+import { AgentWorkspace } from './components/AgentWorkspace';
 import { RegisterDialog } from './components/RegisterDialog';
 import { InputBroadcastProvider } from './contexts/InputBroadcastContext';
-import { WorkspacePaneProvider, useWorkspacePane } from './contexts/WorkspacePaneContext';
+import { WorkspacePaneProvider, useWorkspacePane, type WorkspacePane } from './contexts/WorkspacePaneContext';
 import { api } from './utils/api';
-import type { NamedTheme } from './types';
+import type { AgentDefinition, AgentsConfig, HostSwitcherConfig, NamedTheme } from './types';
 import { loadBundledThemes, loadGlobalTheme, saveGlobalTheme } from './utils/themes';
 
 interface AuthenticatedAppProps {
@@ -40,6 +41,25 @@ interface AuthenticatedAppProps {
   onGlobalLockChange: (on: boolean) => void;
   onGlobalLockSync: (on: boolean) => void;
   globalLockVersion: number;
+  agentConfig: AgentsConfig;
+  hostSwitcher: HostSwitcherConfig;
+}
+
+const DEFAULT_AGENT_CONFIG: AgentsConfig = {
+  enabled: false,
+  combined_pane: true,
+  disable_in_multi_user_mode: true,
+  definitions: [],
+};
+
+const DEFAULT_HOST_SWITCHER: HostSwitcherConfig = {
+  enabled: false,
+  suffixes: [],
+  hosts: [],
+};
+
+function enabledAgentDefinitions(config: AgentsConfig): AgentDefinition[] {
+  return config.enabled ? config.definitions.filter(definition => definition.enabled) : [];
 }
 
 function AuthenticatedApp({
@@ -67,8 +87,36 @@ function AuthenticatedApp({
   onGlobalLockChange,
   onGlobalLockSync,
   globalLockVersion,
+  agentConfig,
+  hostSwitcher,
 }: AuthenticatedAppProps) {
-  const { activePane } = useWorkspacePane();
+  const { activePane, setActivePane } = useWorkspacePane();
+  const agentDefinitions = useMemo(() => enabledAgentDefinitions(agentConfig), [agentConfig]);
+  const combinedAgentPane = agentConfig.combined_pane !== false;
+  const agentWorkspacePanes = useMemo(
+    () => new Set<WorkspacePane>(combinedAgentPane ? ['agents'] : agentDefinitions.map(definition => definition.workspace)),
+    [agentDefinitions, combinedAgentPane],
+  );
+  const [mountedAgentPanes, setMountedAgentPanes] = useState<Set<WorkspacePane>>(() => new Set());
+
+  useEffect(() => {
+    if (!agentWorkspacePanes.has(activePane)) return;
+    setMountedAgentPanes(prev => {
+      if (prev.has(activePane)) return prev;
+      const next = new Set(prev);
+      next.add(activePane);
+      return next;
+    });
+  }, [activePane, agentWorkspacePanes]);
+
+  const shouldMountAgentPane = useCallback(
+    (pane: WorkspacePane) => activePane === pane || mountedAgentPanes.has(pane),
+    [activePane, mountedAgentPanes],
+  );
+
+  const handleAgentAccessDenied = useCallback(() => {
+    setActivePane('terminals');
+  }, [setActivePane]);
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
@@ -89,6 +137,9 @@ function AuthenticatedApp({
         onGlobalAutoScrollChange={onGlobalAutoScrollChange}
         globalLock={globalLock}
         onGlobalLockChange={onGlobalLockChange}
+        agentDefinitions={agentDefinitions}
+        combinedAgentPane={combinedAgentPane}
+        hostSwitcher={hostSwitcher}
       />
 
       <div style={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
@@ -111,6 +162,35 @@ function AuthenticatedApp({
         <div style={{ display: activePane === 'desktops' ? 'flex' : 'none', height: '100%', flexDirection: 'column' }}>
           <GraphicsWorkspace />
         </div>
+        {agentDefinitions.length > 0 && combinedAgentPane && shouldMountAgentPane('agents') && (
+          <div style={{ display: activePane === 'agents' ? 'flex' : 'none', height: '100%', flexDirection: 'column' }}>
+            <AgentWorkspace
+              agentDefinitions={agentDefinitions}
+              fontSize={fontSize}
+              termCols={termCols}
+              termRows={termRows}
+              themes={themes}
+              globalTheme={globalTheme}
+              onAgentAccessDenied={handleAgentAccessDenied}
+            />
+          </div>
+        )}
+        {agentDefinitions.length > 0 && !combinedAgentPane && agentDefinitions.map(definition => (
+          shouldMountAgentPane(definition.workspace) && (
+            <div key={definition.id} style={{ display: activePane === definition.workspace ? 'flex' : 'none', height: '100%', flexDirection: 'column' }}>
+              <AgentWorkspace
+                agent={definition}
+                agentDefinitions={agentDefinitions}
+                fontSize={fontSize}
+                termCols={termCols}
+                termRows={termRows}
+                themes={themes}
+                globalTheme={globalTheme}
+                onAgentAccessDenied={handleAgentAccessDenied}
+              />
+            </div>
+          )
+        ))}
       </div>
 
       {showRegister && (
@@ -155,6 +235,9 @@ export default function App() {
   const [globalAutoScrollVersion, setGlobalAutoScrollVersion] = useState(0);
   const [globalLock, setGlobalLock] = useState(false);
   const [globalLockVersion, setGlobalLockVersion] = useState(0);
+  const [defaultPane, setDefaultPane] = useState<WorkspacePane>('terminals');
+  const [agentConfig, setAgentConfig] = useState<AgentsConfig>(DEFAULT_AGENT_CONFIG);
+  const [hostSwitcher, setHostSwitcher] = useState<HostSwitcherConfig>(DEFAULT_HOST_SWITCHER);
 
   const currentUser = useMemo(() => auth.isAuthenticated ? parseTokenUser() : null, [auth.isAuthenticated]);
 
@@ -172,6 +255,9 @@ export default function App() {
         maxCols: config.app.terminal_grid?.max_cols ?? null,
         maxRows: config.app.terminal_grid?.max_rows ?? null,
       });
+      setDefaultPane(config.app.ui?.default_pane ?? 'terminals');
+      setAgentConfig(config.app.agents ?? DEFAULT_AGENT_CONFIG);
+      setHostSwitcher(config.app.ui?.host_switcher ?? DEFAULT_HOST_SWITCHER);
     }).catch(() => {});
     return () => { cancelled = true; };
   }, [auth.isAuthenticated, auth.isLoading]);
@@ -201,6 +287,19 @@ export default function App() {
     alert(`Account "${username}" created. You can sign out and sign in as "${username}" to use it.`);
   }, []);
 
+  const availablePanes = useMemo<WorkspacePane[]>(() => {
+    const agentDefinitions = enabledAgentDefinitions(agentConfig);
+    const panes: WorkspacePane[] = ['terminals', 'desktops'];
+    if (agentDefinitions.length > 0) {
+      if (agentConfig.combined_pane !== false) {
+        panes.push('agents');
+      } else {
+        panes.push(...agentDefinitions.map(definition => definition.workspace));
+      }
+    }
+    return panes;
+  }, [agentConfig]);
+
   if (auth.isLoading) {
     return (
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: '#888' }}>
@@ -215,7 +314,7 @@ export default function App() {
 
   return (
     <InputBroadcastProvider>
-      <WorkspacePaneProvider>
+      <WorkspacePaneProvider defaultPane={defaultPane} availablePanes={availablePanes}>
         <AuthenticatedApp
           auth={auth}
           fontSize={fontSize}
@@ -247,6 +346,8 @@ export default function App() {
           }}
           onGlobalLockSync={setGlobalLock}
           globalLockVersion={globalLockVersion}
+          agentConfig={agentConfig}
+          hostSwitcher={hostSwitcher}
         />
       </WorkspacePaneProvider>
     </InputBroadcastProvider>

--- a/webmux/frontend/src/components/AgentWorkspace.tsx
+++ b/webmux/frontend/src/components/AgentWorkspace.tsx
@@ -1,0 +1,728 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Terminal } from './Terminal';
+import { api } from '../utils/api';
+import type {
+  AgentDefinition,
+  AgentRuntimeStatus,
+  AgentTmuxSession,
+  ConnectionState,
+  NamedTheme,
+  Session,
+} from '../types';
+
+interface AgentWorkspaceProps {
+  agent?: AgentDefinition;
+  agentDefinitions: AgentDefinition[];
+  fontSize: number;
+  termCols: number;
+  termRows: number;
+  themes: NamedTheme[];
+  globalTheme: string | null;
+  onAgentAccessDenied?: () => void;
+}
+
+type SortMode = 'recently-ready' | 'waiting-longest' | 'name-asc' | 'name-desc' | 'created-newest' | 'created-oldest';
+
+const SORT_LABELS: Record<SortMode, string> = {
+  'recently-ready': 'Recently ready',
+  'waiting-longest': 'Waiting longest',
+  'name-asc': 'Name A-Z',
+  'name-desc': 'Name Z-A',
+  'created-newest': 'Created newest',
+  'created-oldest': 'Created oldest',
+};
+
+function sessionKey(session: AgentTmuxSession): string {
+  return `${session.agent_id}:${session.name}`;
+}
+
+function isoTime(value: string | undefined): number {
+  if (!value) return 0;
+  const time = Date.parse(value);
+  return Number.isFinite(time) ? time : 0;
+}
+
+function relativeTime(value: string | undefined): string {
+  const time = isoTime(value);
+  if (!time) return 'No output seen';
+  const deltaSeconds = Math.max(0, Math.floor((Date.now() - time) / 1000));
+  if (deltaSeconds < 60) return 'Last output just now';
+  const deltaMinutes = Math.floor(deltaSeconds / 60);
+  if (deltaMinutes < 60) return `Last output ${deltaMinutes}m ago`;
+  const deltaHours = Math.floor(deltaMinutes / 60);
+  if (deltaHours < 48) return `Last output ${deltaHours}h ago`;
+  const deltaDays = Math.floor(deltaHours / 24);
+  return `Last output ${deltaDays}d ago`;
+}
+
+function statusLabel(status: AgentRuntimeStatus): string {
+  if (status === 'waiting') return 'Waiting for input';
+  if (status === 'working') return 'Working';
+  if (status === 'stale') return 'Stale';
+  return 'Unknown';
+}
+
+function statusColor(status: AgentRuntimeStatus): string {
+  if (status === 'waiting') return '#50fa7b';
+  if (status === 'working') return '#5a9af7';
+  if (status === 'stale') return '#caaa4a';
+  return '#777';
+}
+
+function sortSessions(sessions: AgentTmuxSession[], sortMode: SortMode): AgentTmuxSession[] {
+  const sorted = [...sessions];
+  const byName = (a: AgentTmuxSession, b: AgentTmuxSession) =>
+    a.display_name.localeCompare(b.display_name) || a.agent_id.localeCompare(b.agent_id) || a.name.localeCompare(b.name);
+  const byCreated = (a: AgentTmuxSession, b: AgentTmuxSession) =>
+    isoTime(a.created_at) - isoTime(b.created_at) || byName(a, b);
+  const byLastOutput = (a: AgentTmuxSession, b: AgentTmuxSession) =>
+    isoTime(a.last_output_at) - isoTime(b.last_output_at) || byName(a, b);
+  const waitingRank = (session: AgentTmuxSession) => session.status === 'waiting' ? 0 : 1;
+
+  sorted.sort((a, b) => {
+    if (sortMode === 'name-asc') return byName(a, b);
+    if (sortMode === 'name-desc') return -byName(a, b);
+    if (sortMode === 'created-newest') return isoTime(b.created_at) - isoTime(a.created_at) || byName(a, b);
+    if (sortMode === 'created-oldest') return byCreated(a, b);
+
+    const waitingDiff = waitingRank(a) - waitingRank(b);
+    if (waitingDiff) return waitingDiff;
+    if (sortMode === 'waiting-longest') return byLastOutput(a, b);
+    return isoTime(b.last_output_at) - isoTime(a.last_output_at) || byName(a, b);
+  });
+
+  return sorted;
+}
+
+function useFlipListAnimation(listRef: React.RefObject<HTMLDivElement | null>, itemKeys: string[], enabled: boolean) {
+  const previousRects = useRef<Map<string, DOMRect>>(new Map());
+
+  useLayoutEffect(() => {
+    const container = listRef.current;
+    if (!container) return;
+
+    const currentRects = new Map<string, DOMRect>();
+    for (const element of Array.from(container.querySelectorAll<HTMLElement>('[data-session-key]'))) {
+      const key = element.dataset.sessionKey;
+      if (!key) continue;
+      const nextRect = element.getBoundingClientRect();
+      const previousRect = previousRects.current.get(key);
+      currentRects.set(key, nextRect);
+
+      if (enabled && previousRect) {
+        const deltaY = previousRect.top - nextRect.top;
+        if (Math.abs(deltaY) > 1) {
+          element.animate(
+            [
+              { transform: `translateY(${deltaY}px)` },
+              { transform: 'translateY(0)' },
+            ],
+            { duration: 180, easing: 'ease-out' },
+          );
+        }
+      }
+    }
+
+    previousRects.current = currentRects;
+  }, [enabled, itemKeys.join('|'), listRef]);
+}
+
+function fallbackDefinition(agentId: string): AgentDefinition {
+  return {
+    id: agentId,
+    label: agentId,
+    plural_label: `${agentId} Sessions`,
+    badge: agentId.toUpperCase().slice(0, 16),
+    tmux_socket: agentId,
+    workspace: `agent-${agentId}`,
+    enabled: true,
+  };
+}
+
+interface TerminalPanelProps {
+  session: Session;
+  fontSize: number;
+  theme?: NamedTheme;
+  agent: AgentDefinition;
+  onClose?: () => void;
+  closeTitle?: string;
+}
+
+function TerminalPanel({ session, fontSize, theme, agent, onClose, closeTitle }: TerminalPanelProps) {
+  const [state, setState] = useState<ConnectionState>(session.state);
+
+  useEffect(() => {
+    setState(session.state);
+  }, [session.id, session.state]);
+
+  return (
+    <div style={styles.panel}>
+      <div style={styles.panelChrome}>
+        <div style={styles.panelTitle}>
+          <span style={{ color: state === 'connected' ? '#4aaa6a' : state === 'error' ? '#ff5555' : '#caaa4a', fontSize: 9 }}>{'\u25cf'}</span>
+          <span style={styles.panelTitleText}>{session.title}</span>
+          {session.agent_role === 'attach' && <span style={styles.roleBadge}>{agent.badge}</span>}
+          {session.agent_role === 'scratch' && <span style={styles.roleBadge}>SHELL</span>}
+        </div>
+        {onClose && (
+          <button style={styles.closeButton} onClick={onClose} title={closeTitle || 'Close'}>
+            x
+          </button>
+        )}
+      </div>
+      <div style={styles.terminalBody}>
+        <Terminal
+          sessionId={session.id}
+          fontSize={fontSize}
+          state={state}
+          autoScroll={true}
+          onStateChange={setState}
+          onViewerUpdate={() => {}}
+          onFocusGained={() => {}}
+          theme={theme?.theme}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function AgentWorkspace({
+  agent,
+  agentDefinitions,
+  fontSize,
+  termCols,
+  termRows,
+  themes,
+  globalTheme,
+  onAgentAccessDenied,
+}: AgentWorkspaceProps) {
+  const combined = agent === undefined;
+  const workspaceLabel = agent ? agent.plural_label : 'Agents';
+  const layoutTestId = agent ? `agent-layout-${agent.id}` : 'agents-layout';
+  const agentById = useMemo(() => {
+    const map = new Map<string, AgentDefinition>();
+    for (const definition of agentDefinitions) map.set(definition.id, definition);
+    if (agent) map.set(agent.id, agent);
+    return map;
+  }, [agent, agentDefinitions]);
+  const availableDefinitions = agent ? [agent] : agentDefinitions;
+
+  const [agentSessions, setAgentSessions] = useState<AgentTmuxSession[]>([]);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [attachedSession, setAttachedSession] = useState<Session | null>(null);
+  const [scratchSession, setScratchSession] = useState<Session | null>(null);
+  const [scratchVisible, setScratchVisible] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [attachLoading, setAttachLoading] = useState(false);
+  const [scratchLoading, setScratchLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sortMode, setSortMode] = useState<SortMode>('recently-ready');
+  const attachRequestRef = useRef(0);
+  const listRef = useRef<HTMLDivElement | null>(null);
+  const sortModeRef = useRef<SortMode>(sortMode);
+  sortModeRef.current = sortMode;
+
+  const activeTheme = themes.find(theme => theme.name === globalTheme);
+  const selectedSession = selectedKey ? agentSessions.find(session => sessionKey(session) === selectedKey) ?? null : null;
+  const selectedAgentId = selectedSession?.agent_id;
+  const selectedAgentName = selectedSession?.name;
+  const sortedSessions = useMemo(() => sortSessions(agentSessions, sortMode), [agentSessions, sortMode]);
+  const sortedKeys = useMemo(() => sortedSessions.map(sessionKey), [sortedSessions]);
+  useFlipListAnimation(listRef, sortedKeys, sortMode === 'recently-ready' || sortMode === 'waiting-longest');
+
+  const deleteAgentSession = useCallback((sessionId: string) => {
+    api.deleteSession(sessionId).catch(err => {
+      console.error(`Failed to delete agent session ${sessionId}:`, err);
+    });
+  }, []);
+
+  const clearAttachedSession = useCallback(() => {
+    setAttachedSession(current => {
+      if (current) {
+        deleteAgentSession(current.id);
+      }
+      return null;
+    });
+  }, [deleteAgentSession]);
+
+  const loadSessions = useCallback(async (options: { showLoading?: boolean } = {}) => {
+    const showLoading = options.showLoading !== false;
+    if (showLoading) setLoading(true);
+    setError(null);
+    try {
+      const loaded = agent ? await api.getAgentSessions(agent.id) : await api.getAllAgentSessions();
+      setAgentSessions(loaded);
+      setSelectedKey(current => {
+        if (current && loaded.some(session => sessionKey(session) === current)) return current;
+        const firstVisibleSession = sortSessions(loaded, sortModeRef.current)[0];
+        return firstVisibleSession ? sessionKey(firstVisibleSession) : null;
+      });
+    } catch (err) {
+      const message = (err as Error).message;
+      if (message === 'Agent sessions are disabled in multi-user mode' || message === 'Agent sessions are not enabled') {
+        onAgentAccessDenied?.();
+      }
+      if (showLoading) {
+        setError(message);
+        setAgentSessions([]);
+        setSelectedKey(null);
+        clearAttachedSession();
+      } else {
+        console.warn(`Failed to refresh ${workspaceLabel}:`, err);
+      }
+    } finally {
+      if (showLoading) setLoading(false);
+    }
+  }, [agent, clearAttachedSession, onAgentAccessDenied, workspaceLabel]);
+
+  useEffect(() => {
+    if (availableDefinitions.length === 0) {
+      setLoading(false);
+      return;
+    }
+    loadSessions();
+  }, [availableDefinitions.length, loadSessions]);
+
+  useEffect(() => {
+    if (!combined || availableDefinitions.length === 0) return;
+    const interval = window.setInterval(() => {
+      loadSessions({ showLoading: false });
+    }, 10000);
+    return () => window.clearInterval(interval);
+  }, [availableDefinitions.length, combined, loadSessions]);
+
+  const attachSelected = useCallback(async (agentId: string, name: string) => {
+    const requestId = ++attachRequestRef.current;
+    setAttachLoading(true);
+    setError(null);
+    try {
+      const session = await api.attachAgentSession(agentId, { name, cols: termCols, rows: termRows });
+      if (attachRequestRef.current === requestId) {
+        setAttachedSession(current => {
+          if (current && current.id !== session.id) {
+            deleteAgentSession(current.id);
+          }
+          return session;
+        });
+      }
+    } catch (err) {
+      if (attachRequestRef.current === requestId) {
+        setError((err as Error).message);
+        clearAttachedSession();
+        await loadSessions();
+      }
+    } finally {
+      if (attachRequestRef.current === requestId) {
+        setAttachLoading(false);
+      }
+    }
+  }, [clearAttachedSession, deleteAgentSession, loadSessions, termCols, termRows]);
+
+  useEffect(() => {
+    if (selectedAgentId && selectedAgentName) {
+      attachSelected(selectedAgentId, selectedAgentName);
+    } else {
+      clearAttachedSession();
+    }
+  }, [attachSelected, clearAttachedSession, selectedAgentId, selectedAgentName]);
+
+  const openScratch = useCallback(async () => {
+    if (scratchLoading) return;
+    const scratchAgentId = selectedSession?.agent_id ?? agent?.id;
+    if (!scratchAgentId) return;
+    setScratchVisible(true);
+    setScratchLoading(true);
+    setError(null);
+    try {
+      const session = await api.createAgentScratch(scratchAgentId, {
+        selectedName: selectedSession?.agent_id === scratchAgentId ? selectedSession.name : undefined,
+        cols: Math.max(40, Math.floor(termCols / 2)),
+        rows: termRows,
+      });
+      setScratchSession(session);
+    } catch (err) {
+      setError((err as Error).message);
+      setScratchSession(null);
+      setScratchVisible(false);
+    } finally {
+      setScratchLoading(false);
+    }
+  }, [agent, scratchLoading, selectedSession, termCols, termRows]);
+
+  const closeScratch = useCallback(async () => {
+    const session = scratchSession;
+    if (!session) return;
+
+    setScratchVisible(false);
+    setScratchSession(null);
+    setError(null);
+    try {
+      await api.deleteSession(session.id);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  }, [scratchSession]);
+
+  const showScratch = scratchVisible && scratchSession;
+  const reserveScratch = scratchVisible || scratchLoading;
+  const attachedAgent = attachedSession?.agent_id
+    ? agentById.get(attachedSession.agent_id) ?? fallbackDefinition(attachedSession.agent_id)
+    : selectedSession
+      ? agentById.get(selectedSession.agent_id) ?? fallbackDefinition(selectedSession.agent_id)
+      : availableDefinitions[0] ?? fallbackDefinition('agent');
+  const scratchAgent = scratchSession?.agent_id
+    ? agentById.get(scratchSession.agent_id) ?? fallbackDefinition(scratchSession.agent_id)
+    : selectedSession
+      ? agentById.get(selectedSession.agent_id) ?? fallbackDefinition(selectedSession.agent_id)
+      : availableDefinitions[0] ?? fallbackDefinition('agent');
+
+  return (
+    <div style={styles.shell}>
+      <aside style={styles.sidebar} data-testid="agent-session-list">
+        <div style={styles.sidebarHeader}>
+          <div>
+            <div style={styles.sidebarTitle}>{workspaceLabel}</div>
+            <div style={styles.sidebarSubtitle}>{loading ? 'Loading sessions' : `${agentSessions.length} session${agentSessions.length === 1 ? '' : 's'}`}</div>
+          </div>
+          <button style={styles.iconButton} onClick={() => loadSessions()} title={`Refresh ${workspaceLabel}`}>
+            Refresh
+          </button>
+        </div>
+
+        <div style={styles.sidebarControls}>
+          <select
+            style={styles.sortSelect}
+            value={sortMode}
+            onChange={event => setSortMode(event.target.value as SortMode)}
+            aria-label="Sort agent sessions"
+          >
+            {(Object.keys(SORT_LABELS) as SortMode[]).map(mode => (
+              <option key={mode} value={mode}>{SORT_LABELS[mode]}</option>
+            ))}
+          </select>
+          <button
+            style={styles.shellButton}
+            onClick={openScratch}
+            disabled={scratchLoading || scratchVisible || (combined && !selectedSession)}
+            title={showScratch ? 'Scratch shell open' : scratchVisible ? 'Scratch shell opening' : combined && !selectedSession ? 'Select a session first' : 'Open scratch shell'}
+          >
+            + Shell
+          </button>
+        </div>
+
+        {loading && <div style={styles.emptyListText}>Loading...</div>}
+        {!loading && agentSessions.length === 0 && !error && (
+          <div style={styles.emptyListText}>No {agent ? agent.label : 'agent'} sessions</div>
+        )}
+        <div ref={listRef} style={styles.sessionList}>
+          {sortedSessions.map(session => {
+            const key = sessionKey(session);
+            const selected = key === selectedKey;
+            const sessionAgent = agentById.get(session.agent_id) ?? fallbackDefinition(session.agent_id);
+            return (
+              <button
+                key={key}
+                data-session-key={key}
+                data-testid="agent-session-row"
+                style={{
+                  ...styles.sessionRow,
+                  ...(selected ? styles.sessionRowSelected : {}),
+                }}
+                onClick={() => setSelectedKey(key)}
+                title={`${statusLabel(session.status)}; ${session.windows} window${session.windows === 1 ? '' : 's'}, ${session.attached} attached`}
+              >
+                <span style={{ ...styles.statusDot, background: statusColor(session.status) }} />
+                <span style={styles.sessionText}>
+                  <span style={styles.sessionTopLine}>
+                    <span style={styles.sessionName}>{session.display_name}</span>
+                    <span style={styles.kindBadge}>{sessionAgent.badge}</span>
+                  </span>
+                  <span style={styles.sessionMeta}>{relativeTime(session.last_output_at)}</span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </aside>
+
+      <main style={styles.main}>
+        {error && <div style={styles.error}>{error}</div>}
+
+        <div
+          data-testid={layoutTestId}
+          style={{
+            ...styles.layout,
+            gridTemplateColumns: reserveScratch ? 'minmax(0, 2fr) minmax(0, 1fr)' : 'minmax(0, 1fr)',
+          }}
+        >
+          {attachedSession ? (
+            <TerminalPanel
+              session={attachedSession}
+              fontSize={fontSize}
+              theme={activeTheme}
+              agent={attachedAgent}
+            />
+          ) : (
+            <div style={styles.emptyPanel}>{attachLoading ? 'Connecting...' : 'No session selected'}</div>
+          )}
+          {showScratch && (
+            <TerminalPanel
+              session={scratchSession}
+              fontSize={fontSize}
+              theme={activeTheme}
+              agent={scratchAgent}
+              onClose={closeScratch}
+              closeTitle="Close scratch shell"
+            />
+          )}
+          {!showScratch && scratchVisible && (
+            <div style={styles.emptyPanel}>{loading || scratchLoading ? 'Opening scratch shell...' : 'Scratch shell unavailable'}</div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  shell: {
+    display: 'grid',
+    gridTemplateColumns: '280px minmax(0, 1fr)',
+    minHeight: 0,
+    height: '100%',
+    background: '#0d0d1a',
+    color: '#e0e0e0',
+  },
+  sidebar: {
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: 0,
+    borderRight: '1px solid #2a2a5a',
+    background: '#12122a',
+  },
+  sidebarHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+    padding: '10px 10px 8px',
+    borderBottom: '1px solid #242452',
+    flexShrink: 0,
+  },
+  sidebarTitle: {
+    fontSize: 14,
+    fontWeight: 700,
+    color: '#f0f0ff',
+  },
+  sidebarSubtitle: {
+    color: '#888',
+    fontSize: 11,
+    marginTop: 2,
+  },
+  sidebarControls: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(0, 1fr) auto',
+    gap: 6,
+    padding: 10,
+    borderBottom: '1px solid #242452',
+    flexShrink: 0,
+  },
+  sortSelect: {
+    minWidth: 0,
+    background: '#1a1a3a',
+    border: '1px solid #333366',
+    borderRadius: 4,
+    color: '#ddd',
+    fontSize: 12,
+    padding: '5px 7px',
+  },
+  shellButton: {
+    background: '#1a1a3a',
+    border: '1px solid #333366',
+    borderRadius: 4,
+    color: '#ccc',
+    cursor: 'pointer',
+    fontSize: 12,
+    padding: '5px 9px',
+    whiteSpace: 'nowrap',
+  },
+  iconButton: {
+    background: '#1a1a3a',
+    border: '1px solid #333366',
+    borderRadius: 4,
+    color: '#ccc',
+    cursor: 'pointer',
+    fontSize: 12,
+    lineHeight: 1,
+    padding: '6px 8px',
+  },
+  emptyListText: {
+    color: '#888',
+    fontSize: 12,
+    padding: 12,
+  },
+  sessionList: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 4,
+    minHeight: 0,
+    overflowY: 'auto',
+    padding: 8,
+  },
+  sessionRow: {
+    alignItems: 'center',
+    background: '#171732',
+    border: '1px solid #2e2e5f',
+    borderRadius: 5,
+    color: '#ddd',
+    cursor: 'pointer',
+    display: 'grid',
+    gap: 8,
+    gridTemplateColumns: '10px minmax(0, 1fr)',
+    minHeight: 54,
+    padding: '7px 8px',
+    textAlign: 'left',
+    width: '100%',
+  },
+  sessionRowSelected: {
+    background: '#1f3f2c',
+    border: '1px solid #4aaa6a',
+    color: '#f2fff5',
+  },
+  statusDot: {
+    borderRadius: '50%',
+    boxShadow: '0 0 0 1px rgba(255, 255, 255, 0.18)',
+    display: 'inline-block',
+    height: 8,
+    width: 8,
+  },
+  sessionText: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 3,
+    minWidth: 0,
+  },
+  sessionTopLine: {
+    alignItems: 'center',
+    display: 'flex',
+    gap: 6,
+    minWidth: 0,
+  },
+  sessionName: {
+    flex: '1 1 auto',
+    fontSize: 13,
+    fontWeight: 650,
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  kindBadge: {
+    background: '#22224a',
+    border: '1px solid #38386c',
+    borderRadius: 3,
+    color: '#aaa',
+    flex: '0 0 auto',
+    fontSize: 9,
+    fontWeight: 700,
+    letterSpacing: 0.2,
+    padding: '2px 4px',
+  },
+  sessionMeta: {
+    color: '#999',
+    fontSize: 11,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  main: {
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: 0,
+    minWidth: 0,
+  },
+  error: {
+    color: '#ff8888',
+    background: '#2a1018',
+    borderBottom: '1px solid #552030',
+    fontSize: 12,
+    padding: '6px 10px',
+  },
+  layout: {
+    display: 'grid',
+    gap: 8,
+    gridTemplateRows: 'minmax(0, 1fr)',
+    alignItems: 'stretch',
+    minHeight: 0,
+    height: '100%',
+    flex: 1,
+    padding: 8,
+  },
+  panel: {
+    display: 'flex',
+    flexDirection: 'column',
+    minWidth: 0,
+    minHeight: 0,
+    height: '100%',
+    border: '2px solid #333366',
+    borderRadius: 6,
+    overflow: 'hidden',
+    background: '#0d0d1a',
+  },
+  panelChrome: {
+    alignItems: 'center',
+    background: '#171732',
+    borderBottom: '1px solid #333366',
+    display: 'flex',
+    flexShrink: 0,
+    justifyContent: 'space-between',
+    minHeight: 30,
+    padding: '4px 8px',
+  },
+  panelTitle: {
+    alignItems: 'center',
+    display: 'flex',
+    gap: 6,
+    minWidth: 0,
+  },
+  panelTitleText: {
+    color: '#ddd',
+    fontSize: 12,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  roleBadge: {
+    background: '#22224a',
+    border: '1px solid #38386c',
+    borderRadius: 3,
+    color: '#aaa',
+    fontSize: 10,
+    fontWeight: 700,
+    padding: '2px 5px',
+  },
+  closeButton: {
+    background: '#2a1830',
+    border: '1px solid #663366',
+    borderRadius: 4,
+    color: '#ddd',
+    cursor: 'pointer',
+    fontSize: 12,
+    padding: '2px 6px',
+  },
+  terminalBody: {
+    flex: 1,
+    minHeight: 0,
+    minWidth: 0,
+    overflow: 'hidden',
+  },
+  emptyPanel: {
+    alignItems: 'center',
+    border: '1px dashed #333366',
+    color: '#888',
+    display: 'flex',
+    fontSize: 13,
+    justifyContent: 'center',
+    minHeight: 0,
+  },
+};

--- a/webmux/frontend/src/components/AgentWorkspace.tsx
+++ b/webmux/frontend/src/components/AgentWorkspace.tsx
@@ -284,12 +284,12 @@ export function AgentWorkspace({
   }, [availableDefinitions.length, loadSessions]);
 
   useEffect(() => {
-    if (!combined || availableDefinitions.length === 0) return;
+    if (availableDefinitions.length === 0) return;
     const interval = window.setInterval(() => {
       loadSessions({ showLoading: false });
     }, 10000);
     return () => window.clearInterval(interval);
-  }, [availableDefinitions.length, combined, loadSessions]);
+  }, [availableDefinitions.length, loadSessions]);
 
   const attachSelected = useCallback(async (agentId: string, name: string) => {
     const requestId = ++attachRequestRef.current;

--- a/webmux/frontend/src/components/TopBar.tsx
+++ b/webmux/frontend/src/components/TopBar.tsx
@@ -1,9 +1,27 @@
 import { useState, useRef } from 'react';
 import type { AuthState } from '../hooks/useAuth';
-import type { NamedTheme } from '../types';
+import type { AgentDefinition, HostSwitcherConfig, NamedTheme } from '../types';
 import { useInputBroadcast } from '../contexts/InputBroadcastContext';
 import { useWorkspacePane } from '../contexts/WorkspacePaneContext';
 import { HelpDialog } from './HelpDialog';
+
+function getHostSwitchContext(hostSwitcher?: HostSwitcherConfig) {
+  if (!hostSwitcher?.enabled || hostSwitcher.hosts.length === 0) return null;
+  const hostname = window.location.hostname.toLowerCase();
+  const suffixes = hostSwitcher.suffixes.map(suffix => suffix.toLowerCase());
+  if (suffixes.length > 0 && !suffixes.some(suffix => hostname === suffix || hostname.endsWith(`.${suffix}`))) {
+    return null;
+  }
+  const protocol = window.location.protocol || 'https:';
+  const current = hostSwitcher.hosts.find(host => host.hostname.toLowerCase() === hostname);
+  return {
+    currentId: current?.id ?? null,
+    hosts: hostSwitcher.hosts.map(host => ({
+      ...host,
+      href: `${protocol}//${host.hostname}/`,
+    })),
+  };
+}
 
 interface TopBarProps {
   auth: AuthState;
@@ -22,6 +40,9 @@ interface TopBarProps {
   onGlobalAutoScrollChange: (on: boolean) => void;
   globalLock: boolean;
   onGlobalLockChange: (on: boolean) => void;
+  agentDefinitions?: AgentDefinition[];
+  combinedAgentPane?: boolean;
+  hostSwitcher?: HostSwitcherConfig;
 }
 
 export function TopBar({
@@ -41,6 +62,9 @@ export function TopBar({
   onGlobalAutoScrollChange,
   globalLock,
   onGlobalLockChange,
+  agentDefinitions = [],
+  combinedAgentPane = true,
+  hostSwitcher,
 }: TopBarProps) {
   const { broadcastMode, setBroadcastMode } = useInputBroadcast();
   const { activePane, setActivePane } = useWorkspacePane();
@@ -48,6 +72,7 @@ export function TopBar({
   const [editingSize, setEditingSize] = useState(false);
   const [sizeInput, setSizeInput] = useState('');
   const sizeInputRef = useRef<HTMLInputElement>(null);
+  const hostSwitchContext = getHostSwitchContext(hostSwitcher);
 
   const commitSize = () => {
     const match = sizeInput.match(/^\s*(\d+)\s*[x×]\s*(\d+)\s*$/i);
@@ -106,6 +131,39 @@ export function TopBar({
         >
           Desktops
         </button>
+        {agentDefinitions.length > 0 && combinedAgentPane && (
+          <button
+            onClick={() => setActivePane('agents')}
+            style={{
+              background: activePane === 'agents' ? '#4aaa6a' : '#1a1a3a',
+              color: '#fff',
+              border: '1px solid #333366',
+              borderRadius: 4,
+              padding: '4px 12px',
+              cursor: 'pointer',
+              fontSize: 13,
+            }}
+          >
+            Agents
+          </button>
+        )}
+        {agentDefinitions.length > 0 && !combinedAgentPane && agentDefinitions.map(definition => (
+          <button
+            key={definition.id}
+            onClick={() => setActivePane(definition.workspace)}
+            style={{
+              background: activePane === definition.workspace ? '#4aaa6a' : '#1a1a3a',
+              color: '#fff',
+              border: '1px solid #333366',
+              borderRadius: 4,
+              padding: '4px 12px',
+              cursor: 'pointer',
+              fontSize: 13,
+            }}
+          >
+            {definition.plural_label}
+          </button>
+        ))}
         <button
           style={{
             ...styles.broadcastBtn,
@@ -242,6 +300,32 @@ export function TopBar({
           </>
         )}
         <button style={styles.helpBtn} onClick={() => setShowHelp(true)} title="Usage help">?</button>
+        {hostSwitchContext && (
+          <div style={styles.hostSwitcher} data-testid="host-switcher" aria-label="Switch WebMux host">
+            {hostSwitchContext.hosts.map(host => (
+              host.id === hostSwitchContext.currentId ? (
+                <span
+                  key={host.id}
+                  style={{ ...styles.hostSwitchButton, ...styles.hostSwitchCurrent }}
+                  data-testid="host-switch-current"
+                  title={`${host.label ?? host.id} is the current host`}
+                >
+                  {host.label ?? host.id}
+                </span>
+              ) : (
+                <a
+                  key={host.id}
+                  href={host.href}
+                  style={styles.hostSwitchButton}
+                  data-testid="host-switch-link"
+                  title={`Open ${host.label ?? host.id}`}
+                >
+                  {host.label ?? host.id}
+                </a>
+              )
+            ))}
+          </div>
+        )}
       </div>
     </div>
     </>
@@ -356,5 +440,29 @@ const styles: Record<string, React.CSSProperties> = {
     flexShrink: 0,
     padding: 0,
     lineHeight: 1,
+  },
+  hostSwitcher: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 4,
+    borderLeft: '1px solid #333366',
+    paddingLeft: 8,
+  },
+  hostSwitchButton: {
+    background: '#1a1a3a',
+    border: '1px solid #333366',
+    borderRadius: 4,
+    color: '#aaa',
+    fontSize: 11,
+    fontWeight: 600,
+    lineHeight: 1,
+    padding: '4px 7px',
+    textDecoration: 'none',
+    whiteSpace: 'nowrap',
+  },
+  hostSwitchCurrent: {
+    background: '#1f3f2c',
+    borderColor: '#4aaa6a',
+    color: '#f2fff5',
   },
 };

--- a/webmux/frontend/src/contexts/WorkspacePaneContext.tsx
+++ b/webmux/frontend/src/contexts/WorkspacePaneContext.tsx
@@ -1,7 +1,10 @@
-import { createContext, useContext, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
+import type { WorkspaceName } from '../types';
 
-export type WorkspacePane = 'terminals' | 'desktops';
+export type WorkspacePane = WorkspaceName;
+
+export const DEFAULT_WORKSPACE_PANE: WorkspacePane = 'terminals';
 
 interface WorkspacePaneContextValue {
   activePane: WorkspacePane;
@@ -9,12 +12,39 @@ interface WorkspacePaneContextValue {
 }
 
 const WorkspacePaneContext = createContext<WorkspacePaneContextValue>({
-  activePane: 'terminals',
+  activePane: DEFAULT_WORKSPACE_PANE,
   setActivePane: () => {},
 });
 
-export function WorkspacePaneProvider({ children }: { children: ReactNode }) {
-  const [activePane, setActivePane] = useState<WorkspacePane>('terminals');
+export function WorkspacePaneProvider({
+  children,
+  defaultPane = DEFAULT_WORKSPACE_PANE,
+  availablePanes = ['terminals', 'desktops'],
+}: {
+  children: ReactNode;
+  defaultPane?: WorkspacePane;
+  availablePanes?: WorkspacePane[];
+}) {
+  const availableKey = availablePanes.join('\0');
+  const available = useMemo(() => new Set(availablePanes), [availableKey]);
+  const [activePane, setActivePaneState] = useState<WorkspacePane>(defaultPane);
+  const userSelectedPane = useRef(false);
+
+  useEffect(() => {
+    if (!available.has(activePane)) {
+      setActivePaneState(available.has(defaultPane) ? defaultPane : DEFAULT_WORKSPACE_PANE);
+      return;
+    }
+    if (!userSelectedPane.current && activePane !== defaultPane && available.has(defaultPane)) {
+      setActivePaneState(defaultPane);
+    }
+  }, [activePane, available, defaultPane]);
+
+  const setActivePane = useCallback((pane: WorkspacePane) => {
+    userSelectedPane.current = true;
+    setActivePaneState(pane);
+  }, []);
+
   return (
     <WorkspacePaneContext.Provider value={{ activePane, setActivePane }}>
       {children}

--- a/webmux/frontend/src/types/index.ts
+++ b/webmux/frontend/src/types/index.ts
@@ -1,6 +1,10 @@
 export type TransportType = 'ssh' | 'mosh' | 'exec';
 export type SessionKind = 'terminal' | 'vnc' | 'rdp';
 export type ConnectionState = 'connecting' | 'connected' | 'disconnected' | 'error';
+export type WorkspaceName = 'terminals' | 'desktops' | 'agents' | string;
+export type AgentSessionRole = 'attach' | 'scratch';
+export type AgentRuntimeStatus = 'waiting' | 'working' | 'unknown' | 'stale';
+export type AgentStatusSource = 'hook' | 'tmux' | 'webmux' | 'none';
 
 export interface Session {
   id: string;
@@ -12,6 +16,8 @@ export interface Session {
   username: string;
   key_id: string;
   exec_command?: string;
+  exec_argv?: string[];
+  exec_cwd?: string;
   cols: number;
   rows: number;
   row: number;
@@ -22,6 +28,10 @@ export interface Session {
   title: string;
   persistent: boolean;
   minimized: boolean;
+  workspace?: WorkspaceName;
+  agent_id?: string;
+  agent_role?: AgentSessionRole;
+  agent_session_name?: string;
 }
 
 export interface TerminalTheme {
@@ -103,6 +113,47 @@ export interface CreateSessionRequest {
   col?: number;
 }
 
+export interface AgentTmuxSession {
+  name: string;
+  agent_id: string;
+  display_name: string;
+  windows: number;
+  attached: number;
+  created_at?: string;
+  last_output_at?: string;
+  status: AgentRuntimeStatus;
+  status_source: AgentStatusSource;
+}
+
+export interface AgentDefinition {
+  id: string;
+  label: string;
+  plural_label: string;
+  badge: string;
+  tmux_socket: string;
+  workspace: WorkspaceName;
+  enabled: boolean;
+}
+
+export interface AgentsConfig {
+  enabled: boolean;
+  combined_pane: boolean;
+  disable_in_multi_user_mode: boolean;
+  definitions: AgentDefinition[];
+}
+
+export interface HostSwitcherHost {
+  id: string;
+  label?: string;
+  hostname: string;
+}
+
+export interface HostSwitcherConfig {
+  enabled: boolean;
+  suffixes: string[];
+  hosts: HostSwitcherHost[];
+}
+
 export interface KeyEntry {
   id: string;
   type: string;
@@ -127,6 +178,11 @@ export interface AppConfig {
       max_cols?: number | null;
       max_rows?: number | null;
     };
+    ui?: {
+      default_pane?: WorkspaceName;
+      host_switcher?: HostSwitcherConfig;
+    };
+    agents?: AgentsConfig;
     // Set by WEBMUX_EXEC_COMMAND on the server; drives exec-transport defaults in the UI.
     exec_command?: string;
   };

--- a/webmux/frontend/src/utils/api.ts
+++ b/webmux/frontend/src/utils/api.ts
@@ -1,4 +1,18 @@
-import type { Session, HostEntry, KeyEntry, AuthStatus, AppConfig, DeepPartial, CreateSessionRequest, VncSession, CreateVncSessionRequest, RdpSession, CreateRdpSessionRequest } from '../types';
+import type {
+  AgentTmuxSession,
+  AppConfig,
+  AuthStatus,
+  CreateRdpSessionRequest,
+  CreateSessionRequest,
+  CreateVncSessionRequest,
+  DeepPartial,
+  HostEntry,
+  KeyEntry,
+  AgentsConfig,
+  RdpSession,
+  Session,
+  VncSession,
+} from '../types';
 
 const API_BASE = '/api';
 
@@ -140,6 +154,15 @@ export const api = {
   getConfig: () => request<AppConfig>('/config'),
   updateConfig: (config: DeepPartial<AppConfig>) =>
     request<AppConfig>('/config', { method: 'PUT', body: JSON.stringify(config) }),
+
+  // Agent sessions
+  getAgentConfig: () => request<AgentsConfig>('/agents/config'),
+  getAllAgentSessions: () => request<AgentTmuxSession[]>('/agents/sessions'),
+  getAgentSessions: (agentId: string) => request<AgentTmuxSession[]>(`/agents/${agentId}/sessions`),
+  attachAgentSession: (agentId: string, req: { name: string; cols: number; rows: number }) =>
+    request<Session>(`/agents/${agentId}/attach`, { method: 'POST', body: JSON.stringify(req) }),
+  createAgentScratch: (agentId: string, req: { selectedName?: string; cols: number; rows: number }) =>
+    request<Session>(`/agents/${agentId}/scratch`, { method: 'POST', body: JSON.stringify(req) }),
 };
 
 export function buildWsUrl(sessionId: string): string {

--- a/webmux/frontend/vite.config.ts
+++ b/webmux/frontend/vite.config.ts
@@ -23,10 +23,16 @@ export default defineConfig({
   resolve: {
     alias: {
       '@frontend': path.resolve(__dirname, 'src'),
+      '@testing-library/react': path.resolve(__dirname, '../node_modules/@testing-library/react'),
+      react: path.resolve(__dirname, '../node_modules/react'),
+      'react-dom': path.resolve(__dirname, '../node_modules/react-dom'),
     },
     preserveSymlinks: true,
   },
   server: {
+    fs: {
+      allow: [path.resolve(__dirname, '../..')],
+    },
     proxy: {
       '/api': {
         target: 'http://localhost:8080',
@@ -54,6 +60,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    include: ['../../tests/frontend/**/*.{test,spec}.?(c|m)[jt]s?(x)'],
     setupFiles: './src/test/setup.ts',
     server: {
       deps: {

--- a/webmux/scripts/webmux-agent-status.js
+++ b/webmux/scripts/webmux-agent-status.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const AGENT_ID_RE = /^[a-z][a-z0-9_-]{0,63}$/;
+const VALID_STATUSES = new Set(['waiting', 'working', 'unknown', 'stale']);
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) continue;
+    const key = arg.slice(2).replace(/-/g, '_');
+    const value = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[++i] : 'true';
+    args[key] = value;
+  }
+  return args;
+}
+
+function tmuxSocketArgs(socket) {
+  if (!socket) return [];
+  return path.isAbsolute(socket) ? ['-S', socket] : ['-L', socket];
+}
+
+function tmuxSocketPathFromEnv(value) {
+  if (!value) return undefined;
+  return value.split(',')[0] || undefined;
+}
+
+function tmuxSessionFromPane(pane, socket) {
+  if (!pane) return undefined;
+  const displayArgs = ['display-message', '-p', '-t', pane, '#S'];
+  const attempts = [];
+  const configuredSocketArgs = tmuxSocketArgs(socket);
+  if (configuredSocketArgs.length) attempts.push([...configuredSocketArgs, ...displayArgs]);
+  const tmuxEnvSocketArgs = tmuxSocketArgs(tmuxSocketPathFromEnv(process.env.TMUX));
+  if (tmuxEnvSocketArgs.length) attempts.push([...tmuxEnvSocketArgs, ...displayArgs]);
+  attempts.push(displayArgs);
+
+  for (const args of attempts) {
+    try {
+      const output = execFileSync('tmux', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+      if (output) return output;
+    } catch {
+      // Try the next tmux addressing mode.
+    }
+  }
+  return undefined;
+}
+
+function resolveSessionName(args) {
+  return args.name ||
+    process.env.WEBMUX_AGENT_SESSION ||
+    tmuxSessionFromPane(process.env.TMUX_PANE, args.tmux_socket || process.env.WEBMUX_AGENT_TMUX_SOCKET);
+}
+
+function encodeSessionName(name) {
+  return Buffer.from(name, 'utf8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
+}
+
+function statusFile(agentId, name) {
+  const webmuxHome = process.env.WEBMUX_HOME || path.join(os.homedir(), '.config', 'webmux');
+  return path.join(webmuxHome, 'data', 'agent-status', agentId, `${encodeSessionName(name)}.json`);
+}
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+function writeJsonAtomic(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  const tmp = `${file}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  fs.writeFileSync(tmp, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+  fs.renameSync(tmp, file);
+}
+
+async function readStdin() {
+  let input = '';
+  for await (const chunk of process.stdin) {
+    input += chunk.toString('utf8');
+  }
+  if (!input.trim()) return {};
+  try {
+    return JSON.parse(input);
+  } catch {
+    return {};
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const agentId = args.agent || args.kind || 'codex';
+  const status = args.status;
+
+  if (!AGENT_ID_RE.test(agentId) || !VALID_STATUSES.has(status)) return;
+
+  const hookInput = await readStdin();
+  const name = resolveSessionName(args);
+  if (!name) {
+    console.error('webmux-agent-status: could not resolve tmux session name');
+    return;
+  }
+
+  const now = new Date().toISOString();
+  const file = statusFile(agentId, name);
+  const previous = readJson(file);
+  const next = {
+    ...previous,
+    agent_id: agentId,
+    name,
+    status,
+    source: 'hook',
+    updated_at: now,
+    hook_session_id: hookInput.session_id || previous.hook_session_id,
+    hook_turn_id: hookInput.turn_id || previous.hook_turn_id,
+  };
+
+  if (status === 'waiting') {
+    next.last_ready_at = now;
+    next.last_output_at = now;
+    delete next.last_output_source;
+  } else if (status === 'working') {
+    next.last_input_at = now;
+  }
+
+  writeJsonAtomic(file, next);
+}
+
+if (require.main === module) {
+  main().catch(err => {
+    console.error(`webmux-agent-status: ${err.message}`);
+  });
+}
+
+module.exports = {
+  tmuxSessionFromPane,
+  tmuxSocketPathFromEnv,
+};


### PR DESCRIPTION
## Summary

This adds configurable tmux-backed agent session views without changing the default WebMux experience.

- adds `app.ui` and `app.agents` runtime config, with agents disabled by default and `terminals` remaining the default pane
- adds a backend agent service/API that lists configured tmux-backed sessions and exposes status metadata when enabled
- adds a frontend Agents workspace that is entirely driven by `/api/config`, including combined/per-agent panes and the optional host switcher
- adds an optional generic status hook script for JSON status updates, suitable for Codex-style agent integrations
- documents setup and includes a neutral example config using example hostnames only

## Defaults and security posture

- `app.agents.enabled` defaults to `false`
- `app.ui.default_pane` defaults to `terminals`
- `app.ui.host_switcher.enabled` defaults to `false`
- agent routes remain disabled in multi-user mode unless explicitly allowed by config
- tmux attach behavior is constrained to configured agent definitions and named sockets
- status hook output is neutral `agent_id` metadata under WebMux's configured data directory

## Migration notes

Existing users should see no UI or API behavior change unless they opt in by configuring `app.agents.enabled: true`. To enable agent views, install tmux, create named tmux sessions/sockets for the agents, add agent definitions under `WEBMUX_HOME/config/app.yaml`, and restart WebMux. See `docs/agent-views.md` for the setup flow and example config.

## Validation

- `npm run typecheck`
- `npm run test --workspace=backend -- --runTestsByPath ../../tests/backend/agentApi.test.ts ../../tests/backend/sessionBroker.test.ts`
- `npm run test --workspace=frontend -- AgentWorkspace.test.tsx App.test.tsx TopBar.test.tsx WorkspacePaneContext.test.tsx`
- standalone `webmux/scripts/webmux-agent-status.js` smoke test
- `npm run build`
- `npm test`
- runtime smoke test for default config, enabled agent config, and multi-user denial behavior
- `git diff --check upstream/main...HEAD`
- committed-diff scan for private hostnames, private paths, and local deployment terms
