### PR TITLE
Add configurable terminal font family

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ app:
     cols: 80            # terminal width in characters
     rows: 24            # terminal height in characters
     font_size: 14       # font size in pixels
+    font_family: Consolas, Menlo, "DejaVu Sans Mono", monospace
   terminal_grid:
     max_cols: null      # null, 0, or omitted = unlimited
     max_rows: null      # null, 0, or omitted = unlimited
@@ -101,7 +102,7 @@ app:
     ssh_fallback: true
 ```
 
-The `default_term` settings control the size of every terminal tile. Each tile is rendered at a fixed pixel size derived from `cols`, `rows`, and `font_size`. When tiles exceed the browser viewport, the workspace scrolls horizontally and vertically. All three values can also be adjusted live from the top bar — changes are saved back to `app.yaml` automatically.
+The `default_term` settings control every terminal tile's dimensions and fixed-width font. Each tile is rendered at a fixed pixel size derived from `cols`, `rows`, and `font_size`. `font_family` accepts a normal CSS font-family list and is applied across terminal and monospace UI text. Multi-word family names such as `Comic Mono` are normalized to quoted CSS family names, so `Comic Mono` is returned and saved as `"Comic Mono"`. The size values can also be adjusted live from the top bar; changes are saved back to `app.yaml` automatically.
 
 The optional `terminal_grid` settings cap the number of columns and rows available in the terminals workspace. By default both directions are unlimited. `WEBMUX_TERMINAL_GRID_MAX_COLS` and `WEBMUX_TERMINAL_GRID_MAX_ROWS` override the YAML values at runtime; set either variable to a positive integer, or to `0`/`unlimited` for no limit.
 

--- a/docs/webmux.1
+++ b/docs/webmux.1
@@ -79,9 +79,10 @@ the server runs in
 .I Trusted
 mode (no auth, permissive CORS) — suitable for isolated networks only.
 .TP
-.B app.default_term.cols / .rows / .font_size
-Default terminal dimensions and font size for new sessions.
-Users can adjust these at runtime from the top bar; changes are
+.B app.default_term.cols / .rows / .font_size / .font_family
+Default terminal dimensions, font size, and CSS font-family for new sessions.
+Multi-word font family names are normalized to quoted CSS family names.
+Users can adjust the size values at runtime from the top bar; changes are
 persisted back to this file.
 .TP
 .B app.terminal_grid.max_cols / .max_rows

--- a/tests/backend/apiRoutes.test.ts
+++ b/tests/backend/apiRoutes.test.ts
@@ -179,6 +179,7 @@ describe('API Routes', () => {
       const res = await request(app).get('/api/config');
       expect(res.status).toBe(200);
       expect(res.body.app.name).toBe('webmux');
+      expect(res.body.app.default_term.font_family).toBe('Consolas, Menlo, "DejaVu Sans Mono", monospace');
     });
 
     it('returns environment-overridden terminal grid limits', async () => {
@@ -208,6 +209,30 @@ describe('API Routes', () => {
         .send({ app: { name: 'updated' } });
       expect(res.status).toBe(200);
       expect(res.body.app.name).toBe('updated');
+    });
+
+    it('quotes terminal font family and preserves it across size-only updates', async () => {
+      const fontRes = await request(app)
+        .put('/api/config')
+        .send({ app: { default_term: { font_family: 'Test Fixture Sans' } } });
+      expect(fontRes.status).toBe(200);
+      expect(fontRes.body.app.default_term.font_family).toBe('"Test Fixture Sans"');
+      expect(fontRes.body.app.default_term.font_size).toBe(14);
+
+      const sizeRes = await request(app)
+        .put('/api/config')
+        .send({ app: { default_term: { font_size: 18 } } });
+      expect(sizeRes.status).toBe(200);
+      expect(sizeRes.body.app.default_term.font_family).toBe('"Test Fixture Sans"');
+      expect(sizeRes.body.app.default_term.font_size).toBe(18);
+    });
+
+    it('rejects unsafe terminal font family values', async () => {
+      const res = await request(app)
+        .put('/api/config')
+        .send({ app: { default_term: { font_family: 'Test Fixture Sans; color: red' } } });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Invalid app.default_term.font_family');
     });
 
     it('updates terminal grid limits', async () => {

--- a/tests/frontend/App.test.tsx
+++ b/tests/frontend/App.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
 
 // Mock useAuth before importing App
 const mockAuth = {
@@ -100,6 +100,7 @@ const mockSession = {
 describe('App', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    document.documentElement.style.removeProperty('--webmux-mono-font');
     (api.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue(defaultConfig);
     (api.getSessions as ReturnType<typeof vi.fn>).mockResolvedValue([]);
     mockAuth.isAuthenticated = false;
@@ -219,6 +220,38 @@ describe('App', () => {
     await waitFor(() => {
       expect(screen.getByTestId('add-cell-0-1')).toBeDefined();
       expect(screen.queryByTestId('add-cell-1-0')).toBeNull();
+    });
+  });
+
+  it('applies configured terminal font family and keeps it when saving font size', async () => {
+    mockAuth.isLoading = false;
+    mockAuth.isAuthenticated = true;
+    mockAuth.authStatus = { mode: 'none', bootstrap_required: false };
+    (api.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue({
+      app: {
+        ...defaultConfig.app,
+        default_term: { cols: 80, rows: 24, font_size: 14, font_family: '"Test Fixture Sans"' },
+      },
+    });
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(document.documentElement.style.getPropertyValue('--webmux-mono-font')).toBe('"Test Fixture Sans"');
+    });
+
+    fireEvent.click(screen.getByText('A+'));
+    await waitFor(() => {
+      expect(api.updateConfig).toHaveBeenCalledWith({
+        app: {
+          default_term: {
+            cols: 80,
+            rows: 24,
+            font_size: 15,
+            font_family: '"Test Fixture Sans"',
+          },
+        },
+      });
     });
   });
 });

--- a/webmux/README.md
+++ b/webmux/README.md
@@ -50,12 +50,15 @@ app:
     cols: 80
     rows: 24
     font_size: 14
+    font_family: Consolas, Menlo, "DejaVu Sans Mono", monospace
   terminal_grid:
     max_cols: null      # null, 0, or omitted = unlimited
     max_rows: null      # null, 0, or omitted = unlimited
 ```
 
 `WEBMUX_TERMINAL_GRID_MAX_COLS` and `WEBMUX_TERMINAL_GRID_MAX_ROWS` can override those YAML values at runtime.
+
+Multi-word `default_term.font_family` values such as `Comic Mono` are normalized to quoted CSS family names, so `Comic Mono` is returned and saved as `"Comic Mono"`.
 
 Agent views are configured under `app.agents` and are disabled by default. See `../docs/agent-views.md` and `examples/agent-views/app.yaml` for setup, security notes, optional status hooks, and host-switcher examples.
 

--- a/webmux/backend/src/api/config.ts
+++ b/webmux/backend/src/api/config.ts
@@ -50,18 +50,47 @@ router.put('/', (req: Request, res: Response) => {
         return;
       }
     }
-    const merged = { app: { ...current.app, ...updates } };
+    const merged = {
+      app: {
+        ...current.app,
+        ...updates,
+        default_term: updates.default_term
+          ? { ...current.app.default_term, ...updates.default_term }
+          : current.app.default_term,
+        terminal_grid: updates.terminal_grid
+          ? { ...current.app.terminal_grid, ...updates.terminal_grid }
+          : current.app.terminal_grid,
+        transport: updates.transport
+          ? { ...current.app.transport, ...updates.transport }
+          : current.app.transport,
+        ui: updates.ui
+          ? { ...current.app.ui, ...updates.ui }
+          : current.app.ui,
+      },
+    };
+    let normalized;
     try {
       terminalGridLimitsFromApp(merged);
+      normalized = normalizeAppConfig(merged);
     } catch (err) {
       if (isTerminalGridLimitError(err)) {
         res.status(400).json({ error: (err as Error).message });
         return;
       }
+      if ((err as Error).message === 'Invalid app.default_term.font_family') {
+        res.status(400).json({ error: (err as Error).message });
+        return;
+      }
       throw err;
     }
-    persistence.saveApp(merged);
-    res.json(normalizeAppConfig(appConfigWithEffectiveTerminalGridLimits(merged)));
+    const persisted = {
+      app: {
+        ...merged.app,
+        default_term: normalized.app.default_term,
+      },
+    };
+    persistence.saveApp(persisted);
+    res.json(normalizeAppConfig(appConfigWithEffectiveTerminalGridLimits(persisted)));
   } catch {
     res.status(500).json({ error: 'Failed to save config' });
   }

--- a/webmux/backend/src/index.ts
+++ b/webmux/backend/src/index.ts
@@ -25,7 +25,7 @@ import { sessionBroker } from './services/sessionBroker';
 import { vncBroker } from './services/vncBroker';
 import { rdpBroker } from './services/rdpBroker';
 import { persistence } from './services/persistenceManager';
-import { normalizeAppConfig } from './services/appConfig';
+import { DEFAULT_TERMINAL_FONT_FAMILY, normalizeAppConfig } from './services/appConfig';
 
 const WEBMUX_ROOT = process.env.WEBMUX_ROOT || path.join(__dirname, '../..');
 
@@ -43,7 +43,7 @@ async function main(): Promise<void> {
         https_port: 8443,
         secure_mode: false,
         trusted_http_allowed: true,
-        default_term: { cols: 80, rows: 24, font_size: 14 },
+        default_term: { cols: 80, rows: 24, font_size: 14, font_family: DEFAULT_TERMINAL_FONT_FAMILY },
         terminal_grid: { max_cols: null, max_rows: null },
         ui: { default_pane: 'terminals', host_switcher: { enabled: false, suffixes: [], hosts: [] } },
         agents: { enabled: false, combined_pane: true, disable_in_multi_user_mode: true, definitions: [] },

--- a/webmux/backend/src/services/appConfig.ts
+++ b/webmux/backend/src/services/appConfig.ts
@@ -10,6 +10,22 @@ import type {
 
 const AGENT_ID_RE = /^[a-z][a-z0-9_-]{0,63}$/;
 const TMUX_SOCKET_RE = /^[a-zA-Z0-9_.-]+$/;
+export const DEFAULT_TERMINAL_FONT_FAMILY = 'Consolas, Menlo, "DejaVu Sans Mono", monospace';
+const GENERIC_FONT_FAMILIES = new Set([
+  'serif',
+  'sans-serif',
+  'monospace',
+  'cursive',
+  'fantasy',
+  'system-ui',
+  'ui-serif',
+  'ui-sans-serif',
+  'ui-monospace',
+  'ui-rounded',
+  'emoji',
+  'math',
+  'fangsong',
+]);
 
 function stringOrDefault(value: unknown, fallback: string): string {
   return typeof value === 'string' && value.trim() ? value.trim() : fallback;
@@ -17,6 +33,63 @@ function stringOrDefault(value: unknown, fallback: string): string {
 
 function booleanOrDefault(value: unknown, fallback: boolean): boolean {
   return typeof value === 'boolean' ? value : fallback;
+}
+
+function splitFontFamilyList(fontFamily: string): string[] {
+  const parts: string[] = [];
+  let current = '';
+  let quote: '"' | "'" | null = null;
+
+  for (let i = 0; i < fontFamily.length; i += 1) {
+    const char = fontFamily[i];
+    if (quote) {
+      current += char;
+      if (char === '\\' && i + 1 < fontFamily.length) {
+        i += 1;
+        current += fontFamily[i];
+      } else if (char === quote) {
+        quote = null;
+      }
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      current += char;
+      continue;
+    }
+    if (char === ',') {
+      parts.push(current.trim());
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+  if (quote) throw new Error('Invalid app.default_term.font_family');
+  parts.push(current.trim());
+  if (parts.some(part => !part)) throw new Error('Invalid app.default_term.font_family');
+  return parts;
+}
+
+function normalizeFontFamilyPart(part: string): string {
+  const quote = part[0];
+  if ((quote === '"' || quote === "'") && part[part.length - 1] === quote) return part;
+  if (part.includes('"') || part.includes("'") || part.includes('\\')) {
+    throw new Error('Invalid app.default_term.font_family');
+  }
+  if (GENERIC_FONT_FAMILIES.has(part.toLowerCase()) || !/\s/.test(part)) return part;
+  return `"${part}"`;
+}
+
+function normalizeFontFamily(value: unknown): string {
+  const fontFamily = stringOrDefault(value, DEFAULT_TERMINAL_FONT_FAMILY);
+  if (fontFamily.length > 256 || /[\0\r\n;{}]/.test(fontFamily)) {
+    throw new Error('Invalid app.default_term.font_family');
+  }
+  const normalized = splitFontFamilyList(fontFamily).map(normalizeFontFamilyPart).join(', ');
+  if (normalized.length > 256) {
+    throw new Error('Invalid app.default_term.font_family');
+  }
+  return normalized;
 }
 
 function normalizeWorkspace(value: unknown, id: string): WorkspaceName {
@@ -103,6 +176,10 @@ export function normalizeAppConfig(config: AppConfig): AppConfig {
         ...config.app.terminal_grid,
         max_cols: config.app.terminal_grid?.max_cols ?? null,
         max_rows: config.app.terminal_grid?.max_rows ?? null,
+      },
+      default_term: {
+        ...config.app.default_term,
+        font_family: normalizeFontFamily(config.app.default_term?.font_family),
       },
       ui: {
         default_pane: stringOrDefault(ui.default_pane, 'terminals'),

--- a/webmux/backend/src/services/sessionBroker.ts
+++ b/webmux/backend/src/services/sessionBroker.ts
@@ -660,8 +660,7 @@ export class SessionBroker extends EventEmitter {
     this.pendingAgentStatusUpdates.delete(key);
 
     const previousWrite = this.agentStatusWrites.get(key) ?? Promise.resolve();
-    let write: Promise<void>;
-    write = previousWrite
+    const write = previousWrite
       .catch(() => undefined)
       .then(() => agentService.recordStatus(pending.agentId, pending.name, pending.update))
       .catch(err => console.error(`Failed to record ${pending.agentId} agent status:`, err))

--- a/webmux/backend/src/types/index.ts
+++ b/webmux/backend/src/types/index.ts
@@ -10,6 +10,7 @@ export interface AppConfig {
       cols: number;
       rows: number;
       font_size: number;
+      font_family?: string;
     };
     terminal_grid?: {
       max_cols?: number | null;

--- a/webmux/config.defaults/app.yaml
+++ b/webmux/config.defaults/app.yaml
@@ -9,6 +9,7 @@ app:
     cols: 80
     rows: 24
     font_size: 14
+    font_family: Consolas, Menlo, "DejaVu Sans Mono", monospace
   terminal_grid:
     max_cols: null
     max_rows: null

--- a/webmux/examples/agent-views/app.yaml
+++ b/webmux/examples/agent-views/app.yaml
@@ -9,6 +9,7 @@ app:
     cols: 120
     rows: 40
     font_size: 14
+    font_family: Consolas, Menlo, "DejaVu Sans Mono", monospace
   terminal_grid:
     max_cols: null
     max_rows: null

--- a/webmux/frontend/index.html
+++ b/webmux/frontend/index.html
@@ -7,6 +7,9 @@
     <title>WebMux</title>
     <style>
       *, *::before, *::after { box-sizing: border-box; }
+      :root {
+        --webmux-mono-font: Consolas, Menlo, "DejaVu Sans Mono", monospace;
+      }
       html, body, #root {
         margin: 0;
         padding: 0;
@@ -14,7 +17,7 @@
         height: 100%;
         background: #1a1a2e;
         color: #e0e0e0;
-        font-family: 'Consolas', 'Menlo', 'DejaVu Sans Mono', monospace;
+        font-family: var(--webmux-mono-font);
         overflow: hidden;
       }
     </style>

--- a/webmux/frontend/src/App.tsx
+++ b/webmux/frontend/src/App.tsx
@@ -12,10 +12,16 @@ import { WorkspacePaneProvider, useWorkspacePane, type WorkspacePane } from './c
 import { api } from './utils/api';
 import type { AgentDefinition, AgentsConfig, HostSwitcherConfig, NamedTheme } from './types';
 import { loadBundledThemes, loadGlobalTheme, saveGlobalTheme } from './utils/themes';
+import {
+  DEFAULT_TERMINAL_FONT_FAMILY,
+  TERMINAL_FONT_CSS_VARIABLE,
+  normalizeTerminalFontFamily,
+} from './utils/terminalFont';
 
 interface AuthenticatedAppProps {
   auth: AuthState;
   fontSize: number;
+  fontFamily: string;
   onFontSizeChange: (size: number) => void;
   termCols: number;
   termRows: number;
@@ -65,6 +71,7 @@ function enabledAgentDefinitions(config: AgentsConfig): AgentDefinition[] {
 function AuthenticatedApp({
   auth,
   fontSize,
+  fontFamily,
   onFontSizeChange,
   termCols,
   termRows,
@@ -146,6 +153,7 @@ function AuthenticatedApp({
         <div style={{ display: activePane === 'terminals' ? 'flex' : 'none', height: '100%', flexDirection: 'column' }}>
           <Workspace
             fontSize={fontSize}
+            fontFamily={fontFamily}
             termCols={termCols}
             termRows={termRows}
             terminalGridLimit={terminalGridLimit}
@@ -167,6 +175,7 @@ function AuthenticatedApp({
             <AgentWorkspace
               agentDefinitions={agentDefinitions}
               fontSize={fontSize}
+              fontFamily={fontFamily}
               termCols={termCols}
               termRows={termRows}
               themes={themes}
@@ -182,6 +191,7 @@ function AuthenticatedApp({
                 agent={definition}
                 agentDefinitions={agentDefinitions}
                 fontSize={fontSize}
+                fontFamily={fontFamily}
                 termCols={termCols}
                 termRows={termRows}
                 themes={themes}
@@ -214,13 +224,14 @@ function parseTokenUser(): string | null {
   }
 }
 
-function saveTermSettings(fs: number, cols: number, rows: number) {
-  api.updateConfig({ app: { default_term: { font_size: fs, cols, rows } } }).catch(() => {});
+function saveTermSettings(fs: number, cols: number, rows: number, fontFamily: string) {
+  api.updateConfig({ app: { default_term: { font_size: fs, cols, rows, font_family: fontFamily } } }).catch(() => {});
 }
 
 export default function App() {
   const auth = useAuth();
   const [fontSize, setFontSize] = useState(14);
+  const [fontFamily, setFontFamily] = useState(DEFAULT_TERMINAL_FONT_FAMILY);
   const [termCols, setTermCols] = useState(80);
   const [termRows, setTermRows] = useState(24);
   const [terminalGridLimit, setTerminalGridLimit] = useState<{ maxCols: number | null; maxRows: number | null }>({
@@ -249,6 +260,7 @@ export default function App() {
       if (cancelled) return;
       setSecureMode(config.app.secure_mode);
       setFontSize(config.app.default_term.font_size);
+      setFontFamily(normalizeTerminalFontFamily(config.app.default_term.font_family));
       setTermCols(config.app.default_term.cols);
       setTermRows(config.app.default_term.rows);
       setTerminalGridLimit({
@@ -266,6 +278,10 @@ export default function App() {
     loadBundledThemes().then(setThemes).catch(() => {});
   }, []);
 
+  useEffect(() => {
+    document.documentElement.style.setProperty(TERMINAL_FONT_CSS_VARIABLE, fontFamily);
+  }, [fontFamily]);
+
   const handleGlobalThemeChange = useCallback((name: string | null) => {
     setGlobalTheme(name);
     saveGlobalTheme(name);
@@ -273,14 +289,14 @@ export default function App() {
 
   const handleFontSizeChange = useCallback((size: number) => {
     setFontSize(size);
-    saveTermSettings(size, termCols, termRows);
-  }, [termCols, termRows]);
+    saveTermSettings(size, termCols, termRows, fontFamily);
+  }, [fontFamily, termCols, termRows]);
 
   const handleTermSizeChange = useCallback((cols: number, rows: number) => {
     setTermCols(cols);
     setTermRows(rows);
-    saveTermSettings(fontSize, cols, rows);
-  }, [fontSize]);
+    saveTermSettings(fontSize, cols, rows, fontFamily);
+  }, [fontFamily, fontSize]);
 
   const handleAccountCreated = useCallback((username: string) => {
     setShowRegister(false);
@@ -318,6 +334,7 @@ export default function App() {
         <AuthenticatedApp
           auth={auth}
           fontSize={fontSize}
+          fontFamily={fontFamily}
           onFontSizeChange={handleFontSizeChange}
           termCols={termCols}
           termRows={termRows}

--- a/webmux/frontend/src/components/AgentWorkspace.tsx
+++ b/webmux/frontend/src/components/AgentWorkspace.tsx
@@ -14,6 +14,7 @@ interface AgentWorkspaceProps {
   agent?: AgentDefinition;
   agentDefinitions: AgentDefinition[];
   fontSize: number;
+  fontFamily?: string;
   termCols: number;
   termRows: number;
   themes: NamedTheme[];
@@ -142,13 +143,14 @@ function fallbackDefinition(agentId: string): AgentDefinition {
 interface TerminalPanelProps {
   session: Session;
   fontSize: number;
+  fontFamily?: string;
   theme?: NamedTheme;
   agent: AgentDefinition;
   onClose?: () => void;
   closeTitle?: string;
 }
 
-function TerminalPanel({ session, fontSize, theme, agent, onClose, closeTitle }: TerminalPanelProps) {
+function TerminalPanel({ session, fontSize, fontFamily, theme, agent, onClose, closeTitle }: TerminalPanelProps) {
   const [state, setState] = useState<ConnectionState>(session.state);
 
   useEffect(() => {
@@ -174,6 +176,7 @@ function TerminalPanel({ session, fontSize, theme, agent, onClose, closeTitle }:
         <Terminal
           sessionId={session.id}
           fontSize={fontSize}
+          fontFamily={fontFamily}
           state={state}
           autoScroll={true}
           onStateChange={setState}
@@ -190,6 +193,7 @@ export function AgentWorkspace({
   agent,
   agentDefinitions,
   fontSize,
+  fontFamily,
   termCols,
   termRows,
   themes,
@@ -459,6 +463,7 @@ export function AgentWorkspace({
             <TerminalPanel
               session={attachedSession}
               fontSize={fontSize}
+              fontFamily={fontFamily}
               theme={activeTheme}
               agent={attachedAgent}
             />
@@ -469,6 +474,7 @@ export function AgentWorkspace({
             <TerminalPanel
               session={scratchSession}
               fontSize={fontSize}
+              fontFamily={fontFamily}
               theme={activeTheme}
               agent={scratchAgent}
               onClose={closeScratch}

--- a/webmux/frontend/src/components/HelpDialog.tsx
+++ b/webmux/frontend/src/components/HelpDialog.tsx
@@ -160,7 +160,7 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: 12,
     fontWeight: 600,
     color: '#ccc',
-    fontFamily: 'Consolas, Menlo, monospace',
+    fontFamily: 'var(--webmux-mono-font)',
   },
   desc: {
     fontSize: 12,

--- a/webmux/frontend/src/components/Terminal.tsx
+++ b/webmux/frontend/src/components/Terminal.tsx
@@ -7,6 +7,7 @@ import '@xterm/xterm/css/xterm.css';
 import type { WebSocketMessage, ConnectionState, TerminalTheme } from '../types';
 import { useWebSocket } from '../hooks/useWebSocket';
 import { useInputBroadcast } from '../contexts/InputBroadcastContext';
+import { normalizeTerminalFontFamily } from '../utils/terminalFont';
 
 export const DEFAULT_TERMINAL_THEME: TerminalTheme = {
   background: '#0d0d1a',
@@ -41,6 +42,7 @@ export interface TerminalHandle {
 interface TerminalProps {
   sessionId: string;
   fontSize: number;
+  fontFamily?: string;
   state: ConnectionState;
   autoScroll: boolean;
   onStateChange: (state: ConnectionState) => void;
@@ -53,6 +55,7 @@ interface TerminalProps {
 export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Terminal({
   sessionId,
   fontSize,
+  fontFamily,
   state,
   autoScroll,
   onStateChange,
@@ -164,7 +167,7 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
 
     const term = new XTerm({
       theme: { ...DEFAULT_TERMINAL_THEME, ...(theme || {}) },
-      fontFamily: 'Consolas, Menlo, "DejaVu Sans Mono", monospace',
+      fontFamily: normalizeTerminalFontFamily(fontFamily),
       fontSize,
       cursorBlink: true,
       macOptionIsMeta: /Mac|iPhone|iPad/.test(navigator.platform),
@@ -255,13 +258,14 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     // Re-run only when the session changes; all live callbacks are accessed via refs.
   }, [sessionId, setFocusedSessionId]);
 
-  // Update font size
+  // Update font settings
   useEffect(() => {
     if (termRef.current) {
       termRef.current.options.fontSize = fontSize;
+      termRef.current.options.fontFamily = normalizeTerminalFontFamily(fontFamily);
       fitAddonRef.current?.fit();
     }
-  }, [fontSize]);
+  }, [fontFamily, fontSize]);
 
   // Apply theme changes without tearing down the terminal (preserves scrollback).
   useEffect(() => {

--- a/webmux/frontend/src/components/Tile.tsx
+++ b/webmux/frontend/src/components/Tile.tsx
@@ -7,6 +7,7 @@ import type { Session, ConnectionState, NamedTheme } from '../types';
 interface TileProps {
   session: Session;
   fontSize: number;
+  fontFamily?: string;
   autoScroll?: boolean;
   onAutoScrollToggle?: (id: string) => void;
   locked?: boolean;
@@ -34,6 +35,7 @@ export interface TileHandle {
 export const Tile = forwardRef<TileHandle, TileProps>(function Tile({
   session,
   fontSize,
+  fontFamily,
   autoScroll = true,
   onAutoScrollToggle,
   locked = false,
@@ -256,6 +258,7 @@ export const Tile = forwardRef<TileHandle, TileProps>(function Tile({
           ref={termHandleRef}
           sessionId={session.id}
           fontSize={fontSize}
+          fontFamily={fontFamily}
           state={state}
           autoScroll={autoScroll}
           onStateChange={handleStateChange}

--- a/webmux/frontend/src/components/TopBar.tsx
+++ b/webmux/frontend/src/components/TopBar.tsx
@@ -409,7 +409,7 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: 12,
     minWidth: 48,
     textAlign: 'center',
-    fontFamily: 'monospace',
+    fontFamily: 'var(--webmux-mono-font)',
   },
   modeBadge: {
     border: '1px solid',

--- a/webmux/frontend/src/components/Workspace.tsx
+++ b/webmux/frontend/src/components/Workspace.tsx
@@ -9,6 +9,7 @@ import { loadSessionThemeOverrides, saveSessionThemeOverrides } from '../utils/t
 
 interface WorkspaceProps {
   fontSize: number;
+  fontFamily?: string;
   termCols: number;
   termRows: number;
   themes?: NamedTheme[];
@@ -174,6 +175,7 @@ function AddCell({ row, col, isEmpty, onClick }: {
 
 export function Workspace({
   fontSize,
+  fontFamily,
   termCols,
   termRows,
   themes = [],
@@ -617,6 +619,7 @@ export function Workspace({
                   }}
                   session={session}
                   fontSize={fontSize}
+                  fontFamily={fontFamily}
                   autoScroll={autoScrollOverrides.get(session.id) ?? globalAutoScroll}
                   onAutoScrollToggle={handleAutoScrollToggle}
                   locked={lockOverrides.get(session.id) ?? globalLock}

--- a/webmux/frontend/src/types/index.ts
+++ b/webmux/frontend/src/types/index.ts
@@ -173,6 +173,7 @@ export interface AppConfig {
       cols: number;
       rows: number;
       font_size: number;
+      font_family?: string;
     };
     terminal_grid?: {
       max_cols?: number | null;

--- a/webmux/frontend/src/utils/terminalFont.ts
+++ b/webmux/frontend/src/utils/terminalFont.ts
@@ -1,0 +1,7 @@
+export const DEFAULT_TERMINAL_FONT_FAMILY = 'Consolas, Menlo, "DejaVu Sans Mono", monospace';
+export const TERMINAL_FONT_CSS_VARIABLE = '--webmux-mono-font';
+
+export function normalizeTerminalFontFamily(fontFamily: string | undefined | null): string {
+  const trimmed = fontFamily?.trim();
+  return trimmed || DEFAULT_TERMINAL_FONT_FAMILY;
+}


### PR DESCRIPTION
## Summary

Adds `app.default_term.font_family` so deployments can override the terminal fixed-width font family from `app.yaml` instead of relying on the hard-coded frontend default.

## Details

- Adds backend and frontend config typing for `default_term.font_family`.
- Normalizes the setting with the existing default of `Consolas, Menlo, "DejaVu Sans Mono", monospace`.
- Canonicalizes unquoted multi-word family names to quoted CSS family names, so `Comic Mono` is returned and saved as `"Comic Mono"`.
- Rejects unsafe font-family values that could break out of the CSS declaration path.
- Applies the configured font to xterm instances and the existing monospace UI text via `--webmux-mono-font`.
- Deep-merges runtime `default_term` config updates so changing size values does not drop an existing font-family override.
- Documents the new setting and multi-word normalization behavior in the README files, man page, default config, and agent-view example config.
- Fixes an existing backend `prefer-const` lint failure on the current PR merge ref so CI can complete.

## Validation

- `npm run typecheck`
- `npm run lint`
- `npm run test --workspace=backend -- --runTestsByPath ../../tests/backend/apiRoutes.test.ts`
- `npm run test --workspace=frontend -- App.test.tsx`
- `npm run build`