### PR TITLE
Add config-directed terminal font hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,14 @@ app:
     cols: 80            # terminal width in characters
     rows: 24            # terminal height in characters
     font_size: 14       # font size in pixels
-    font_family: Consolas, Menlo, "DejaVu Sans Mono", monospace
+    font_family: ui-monospace, "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", "DejaVu Sans Mono", monospace
+  font_faces:
+    # Optional local fonts to make available to browser clients.
+    # source paths are relative to this app.yaml file's real path.
+    # - family: Custom Mono
+    #   source: fonts/CustomMono.woff2
+    #   weight: 400
+    #   style: normal
   terminal_grid:
     max_cols: null      # null, 0, or omitted = unlimited
     max_rows: null      # null, 0, or omitted = unlimited
@@ -102,7 +109,9 @@ app:
     ssh_fallback: true
 ```
 
-The `default_term` settings control every terminal tile's dimensions and fixed-width font. Each tile is rendered at a fixed pixel size derived from `cols`, `rows`, and `font_size`. `font_family` accepts a normal CSS font-family list and is applied across terminal and monospace UI text. Multi-word family names such as `Comic Mono` are normalized to quoted CSS family names, so `Comic Mono` is returned and saved as `"Comic Mono"`. The size values can also be adjusted live from the top bar; changes are saved back to `app.yaml` automatically.
+The `default_term` settings control every terminal tile's dimensions and fixed-width font. Each tile is rendered at a fixed pixel size derived from `cols`, `rows`, and `font_size`. `font_family` accepts a normal comma-separated CSS font-family list and is applied across terminal and monospace UI text. Multi-word family names such as `Custom Mono` are normalized to quoted CSS family names, so `Custom Mono, Monaco, monospace` is returned and saved as `"Custom Mono", Monaco, monospace`. The size values can also be adjusted live from the top bar; changes are saved back to `app.yaml` automatically.
+
+Optional `font_faces` entries let WebMux host local font files for browser clients. `source` paths must be relative paths to `.otf`, `.ttf`, `.woff`, or `.woff2` files; they are resolved relative to the real `app.yaml` path, so symlinked config files can keep fonts beside the shared config. The frontend fetches configured font files through authenticated same-origin routes and registers them before refitting terminals. Once a face is declared, reference its `family` name from `default_term.font_family`.
 
 The optional `terminal_grid` settings cap the number of columns and rows available in the terminals workspace. By default both directions are unlimited. `WEBMUX_TERMINAL_GRID_MAX_COLS` and `WEBMUX_TERMINAL_GRID_MAX_ROWS` override the YAML values at runtime; set either variable to a positive integer, or to `0`/`unlimited` for no limit.
 

--- a/docs/webmux.1
+++ b/docs/webmux.1
@@ -81,9 +81,33 @@ mode (no auth, permissive CORS) — suitable for isolated networks only.
 .TP
 .B app.default_term.cols / .rows / .font_size / .font_family
 Default terminal dimensions, font size, and CSS font-family for new sessions.
-Multi-word font family names are normalized to quoted CSS family names.
+The font family accepts a comma-separated CSS font-family list. Multi-word font
+family names are normalized to quoted CSS family names.
 Users can adjust the size values at runtime from the top bar; changes are
 persisted back to this file.
+.TP
+.B app.font_faces
+Optional list of local font files to host for browser clients. Each entry
+contains a
+.B family
+name and relative
+.B source
+path, plus optional
+.BR weight ,
+.BR style ,
+and
+.BR display .
+Source paths resolve relative to the real
+.I app.yaml
+path and may point to
+.IR .otf ,
+.IR .ttf ,
+.IR .woff ,
+or
+.I .woff2
+files. Configured fonts are served through authenticated same-origin routes and
+can be referenced from
+.BR app.default_term.font_family .
 .TP
 .B app.terminal_grid.max_cols / .max_rows
 Optional maximum column and row count for the terminals workspace.

--- a/tests/backend/apiRoutes.test.ts
+++ b/tests/backend/apiRoutes.test.ts
@@ -6,6 +6,7 @@ import request from 'supertest';
 
 describe('API Routes', () => {
   let tmpDir: string;
+  let configDir: string;
   let originalHome: string | undefined;
   let app: express.Express;
 
@@ -14,7 +15,7 @@ describe('API Routes', () => {
     originalHome = process.env.WEBMUX_HOME;
     process.env.WEBMUX_HOME = tmpDir;
 
-    const configDir = path.join(tmpDir, 'config');
+    configDir = path.join(tmpDir, 'config');
     fs.mkdirSync(configDir, { recursive: true });
 
     // Auth mode none so we don't need tokens
@@ -179,7 +180,7 @@ describe('API Routes', () => {
       const res = await request(app).get('/api/config');
       expect(res.status).toBe(200);
       expect(res.body.app.name).toBe('webmux');
-      expect(res.body.app.default_term.font_family).toBe('Consolas, Menlo, "DejaVu Sans Mono", monospace');
+      expect(res.body.app.default_term.font_family).toBe('ui-monospace, "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", "DejaVu Sans Mono", monospace');
     });
 
     it('returns environment-overridden terminal grid limits', async () => {
@@ -200,6 +201,48 @@ describe('API Routes', () => {
         else process.env.WEBMUX_TERMINAL_GRID_MAX_ROWS = originalMaxRows;
       }
     });
+
+    it('returns configured font face URLs and serves configured font files', async () => {
+      const fontDir = path.join(configDir, 'fonts');
+      const fontFile = path.join(fontDir, 'TestFont.woff2');
+      fs.mkdirSync(fontDir, { recursive: true });
+      fs.writeFileSync(fontFile, Buffer.from([0x77, 0x4f, 0x46, 0x32]));
+      fs.writeFileSync(path.join(configDir, 'app.yaml'),
+        'app:\n' +
+        '  name: webmux\n' +
+        '  listen_host: 0.0.0.0\n' +
+        '  http_port: 8080\n' +
+        '  https_port: 8443\n' +
+        '  secure_mode: false\n' +
+        '  trusted_http_allowed: true\n' +
+        '  default_term:\n' +
+        '    cols: 80\n' +
+        '    rows: 24\n' +
+        '    font_size: 14\n' +
+        '  font_faces:\n' +
+        '    - family: Test Fixture Mono\n' +
+        '      source: fonts/TestFont.woff2\n' +
+        '      weight: 400\n' +
+        '      style: normal\n' +
+        '  transport:\n' +
+        '    prefer_mosh: false\n' +
+        '    ssh_fallback: true\n');
+
+      const configRes = await request(app).get('/api/config');
+      expect(configRes.status).toBe(200);
+      expect(configRes.body.app.font_faces).toEqual([{
+        family: 'Test Fixture Mono',
+        source: 'fonts/TestFont.woff2',
+        weight: '400',
+        style: 'normal',
+        url: '/api/config/fonts/0',
+      }]);
+
+      const fontRes = await request(app).get('/api/config/fonts/0');
+      expect(fontRes.status).toBe(200);
+      expect(fontRes.header['content-type']).toContain('font/woff2');
+      expect(fontRes.body).toEqual(Buffer.from([0x77, 0x4f, 0x46, 0x32]));
+    });
   });
 
   describe('PUT /api/config', () => {
@@ -211,19 +254,21 @@ describe('API Routes', () => {
       expect(res.body.app.name).toBe('updated');
     });
 
-    it('quotes terminal font family and preserves it across size-only updates', async () => {
+    it('normalizes a terminal font stack and preserves it across size-only updates', async () => {
+      const fontStack = 'Test Fixture Mono, Monaco, ui-monospace, Menlo, Consolas, "Liberation Mono", monospace';
+      const normalizedFontStack = '"Test Fixture Mono", Monaco, ui-monospace, Menlo, Consolas, "Liberation Mono", monospace';
       const fontRes = await request(app)
         .put('/api/config')
-        .send({ app: { default_term: { font_family: 'Test Fixture Sans' } } });
+        .send({ app: { default_term: { font_family: fontStack } } });
       expect(fontRes.status).toBe(200);
-      expect(fontRes.body.app.default_term.font_family).toBe('"Test Fixture Sans"');
+      expect(fontRes.body.app.default_term.font_family).toBe(normalizedFontStack);
       expect(fontRes.body.app.default_term.font_size).toBe(14);
 
       const sizeRes = await request(app)
         .put('/api/config')
         .send({ app: { default_term: { font_size: 18 } } });
       expect(sizeRes.status).toBe(200);
-      expect(sizeRes.body.app.default_term.font_family).toBe('"Test Fixture Sans"');
+      expect(sizeRes.body.app.default_term.font_family).toBe(normalizedFontStack);
       expect(sizeRes.body.app.default_term.font_size).toBe(18);
     });
 
@@ -233,6 +278,14 @@ describe('API Routes', () => {
         .send({ app: { default_term: { font_family: 'Test Fixture Sans; color: red' } } });
       expect(res.status).toBe(400);
       expect(res.body.error).toBe('Invalid app.default_term.font_family');
+    });
+
+    it('rejects invalid configured font faces', async () => {
+      const res = await request(app)
+        .put('/api/config')
+        .send({ app: { font_faces: [{ family: 'Bad Font', source: 'https://example.com/font.woff2' }] } });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Invalid app.font_faces');
     });
 
     it('updates terminal grid limits', async () => {

--- a/tests/backend/apiRoutes.test.ts
+++ b/tests/backend/apiRoutes.test.ts
@@ -243,6 +243,27 @@ describe('API Routes', () => {
       expect(fontRes.header['content-type']).toContain('font/woff2');
       expect(fontRes.body).toEqual(Buffer.from([0x77, 0x4f, 0x46, 0x32]));
     });
+
+    it('does not serve a configured font symlink outside the config directory', async () => {
+      const fontDir = path.join(configDir, 'fonts');
+      const outsideFont = path.join(tmpDir, 'OutsideFont.woff2');
+      fs.mkdirSync(fontDir, { recursive: true });
+      fs.writeFileSync(outsideFont, Buffer.from([0x77, 0x4f, 0x46, 0x32]));
+      fs.symlinkSync(outsideFont, path.join(fontDir, 'LinkedFont.woff2'));
+      fs.writeFileSync(path.join(configDir, 'app.yaml'),
+        'app:\n' +
+        '  name: webmux\n' +
+        '  default_term:\n' +
+        '    cols: 80\n' +
+        '    rows: 24\n' +
+        '    font_size: 14\n' +
+        '  font_faces:\n' +
+        '    - family: Linked Font\n' +
+        '      source: fonts/LinkedFont.woff2\n');
+
+      const fontRes = await request(app).get('/api/config/fonts/0');
+      expect(fontRes.status).toBe(404);
+    });
   });
 
   describe('PUT /api/config', () => {
@@ -284,6 +305,14 @@ describe('API Routes', () => {
       const res = await request(app)
         .put('/api/config')
         .send({ app: { font_faces: [{ family: 'Bad Font', source: 'https://example.com/font.woff2' }] } });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Invalid app.font_faces');
+    });
+
+    it('rejects configured font paths that escape the config directory', async () => {
+      const res = await request(app)
+        .put('/api/config')
+        .send({ app: { font_faces: [{ family: 'Outside Font', source: '../OutsideFont.woff2' }] } });
       expect(res.status).toBe(400);
       expect(res.body.error).toBe('Invalid app.font_faces');
     });

--- a/tests/frontend/App.test.tsx
+++ b/tests/frontend/App.test.tsx
@@ -224,20 +224,21 @@ describe('App', () => {
   });
 
   it('applies configured terminal font family and keeps it when saving font size', async () => {
+    const fontStack = '"Test Fixture Mono", Monaco, ui-monospace, Menlo, Consolas, "Liberation Mono", monospace';
     mockAuth.isLoading = false;
     mockAuth.isAuthenticated = true;
     mockAuth.authStatus = { mode: 'none', bootstrap_required: false };
     (api.getConfig as ReturnType<typeof vi.fn>).mockResolvedValue({
       app: {
         ...defaultConfig.app,
-        default_term: { cols: 80, rows: 24, font_size: 14, font_family: '"Test Fixture Sans"' },
+        default_term: { cols: 80, rows: 24, font_size: 14, font_family: fontStack },
       },
     });
 
     render(<App />);
 
     await waitFor(() => {
-      expect(document.documentElement.style.getPropertyValue('--webmux-mono-font')).toBe('"Test Fixture Sans"');
+      expect(document.documentElement.style.getPropertyValue('--webmux-mono-font')).toBe(fontStack);
     });
 
     fireEvent.click(screen.getByText('A+'));
@@ -248,7 +249,7 @@ describe('App', () => {
             cols: 80,
             rows: 24,
             font_size: 15,
-            font_family: '"Test Fixture Sans"',
+            font_family: fontStack,
           },
         },
       });

--- a/webmux/README.md
+++ b/webmux/README.md
@@ -50,7 +50,12 @@ app:
     cols: 80
     rows: 24
     font_size: 14
-    font_family: Consolas, Menlo, "DejaVu Sans Mono", monospace
+    font_family: ui-monospace, "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", "DejaVu Sans Mono", monospace
+  font_faces:
+    # - family: Custom Mono
+    #   source: fonts/CustomMono.woff2
+    #   weight: 400
+    #   style: normal
   terminal_grid:
     max_cols: null      # null, 0, or omitted = unlimited
     max_rows: null      # null, 0, or omitted = unlimited
@@ -58,7 +63,9 @@ app:
 
 `WEBMUX_TERMINAL_GRID_MAX_COLS` and `WEBMUX_TERMINAL_GRID_MAX_ROWS` can override those YAML values at runtime.
 
-Multi-word `default_term.font_family` values such as `Comic Mono` are normalized to quoted CSS family names, so `Comic Mono` is returned and saved as `"Comic Mono"`.
+`default_term.font_family` accepts a normal comma-separated CSS font-family list. Multi-word family names such as `Custom Mono` are normalized to quoted CSS family names, so `Custom Mono, Monaco, monospace` is returned and saved as `"Custom Mono", Monaco, monospace`.
+
+Optional `app.font_faces` entries let WebMux host local font files for browser clients. `source` paths must be relative paths to `.otf`, `.ttf`, `.woff`, or `.woff2` files; they are resolved relative to the real `app.yaml` path, so symlinked config files can keep fonts beside the shared config. The frontend fetches configured font files through authenticated same-origin routes and registers them before refitting terminals. Once a face is declared, reference its `family` name from `default_term.font_family`.
 
 Agent views are configured under `app.agents` and are disabled by default. See `../docs/agent-views.md` and `examples/agent-views/app.yaml` for setup, security notes, optional status hooks, and host-switcher examples.
 

--- a/webmux/backend/src/api/config.ts
+++ b/webmux/backend/src/api/config.ts
@@ -1,4 +1,6 @@
 import { Router, Request, Response } from 'express';
+import * as fs from 'fs';
+import * as path from 'path';
 import { persistence } from '../services/persistenceManager';
 import { requireAuth } from '../middleware/auth';
 import { TransportLauncher } from '../services/transportLauncher';
@@ -7,14 +9,53 @@ import {
   isTerminalGridLimitError,
   terminalGridLimitsFromApp,
 } from '../services/terminalGridLimits';
-import { normalizeAppConfig } from '../services/appConfig';
+import { FONT_FACE_CONFIG_ERROR, normalizeAppConfig } from '../services/appConfig';
+import type { AppConfig } from '../types';
 
 const router = Router();
 router.use(requireAuth);
 
+const FONT_CONTENT_TYPES: Record<string, string> = {
+  '.otf': 'font/otf',
+  '.ttf': 'font/ttf',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+};
+
+function appConfigDir(): string {
+  const appConfigFile = persistence.configPath('app.yaml');
+  try {
+    return path.dirname(fs.realpathSync(appConfigFile));
+  } catch {
+    return path.dirname(appConfigFile);
+  }
+}
+
+function withFontFaceUrls(config: AppConfig): AppConfig {
+  return {
+    app: {
+      ...config.app,
+      font_faces: (config.app.font_faces ?? []).map((face, index) => ({
+        ...face,
+        url: `/api/config/fonts/${index}`,
+      })),
+    },
+  };
+}
+
+function configuredFontFile(index: number): { file: string; contentType: string } | null {
+  const app = normalizeAppConfig(appConfigWithEffectiveTerminalGridLimits(persistence.loadApp()));
+  const face = app.app.font_faces?.[index];
+  if (!face) return null;
+  const file = path.resolve(appConfigDir(), face.source);
+  const contentType = FONT_CONTENT_TYPES[path.extname(file).toLowerCase()];
+  if (!contentType) return null;
+  return { file, contentType };
+}
+
 router.get('/', (_req: Request, res: Response) => {
   try {
-    const app = normalizeAppConfig(appConfigWithEffectiveTerminalGridLimits(persistence.loadApp()));
+    const app = withFontFaceUrls(normalizeAppConfig(appConfigWithEffectiveTerminalGridLimits(persistence.loadApp())));
     const execCommand = process.env.WEBMUX_EXEC_COMMAND;
     if (execCommand) {
       app.app.exec_command = execCommand;
@@ -25,8 +66,28 @@ router.get('/', (_req: Request, res: Response) => {
   }
 });
 
+router.get('/fonts/:index', (req: Request, res: Response) => {
+  const index = Number(req.params.index);
+  if (!Number.isInteger(index) || index < 0) {
+    res.status(404).json({ error: 'Font not found' });
+    return;
+  }
+  try {
+    const fontFile = configuredFontFile(index);
+    if (!fontFile || !fs.existsSync(fontFile.file) || !fs.statSync(fontFile.file).isFile()) {
+      res.status(404).json({ error: 'Font not found' });
+      return;
+    }
+    res.type(fontFile.contentType);
+    res.setHeader('Cache-Control', 'private, max-age=3600');
+    res.sendFile(fontFile.file);
+  } catch {
+    res.status(404).json({ error: 'Font not found' });
+  }
+});
+
 // Only allow updating safe fields — not listen_host, ports, or secure_mode at runtime
-const MUTABLE_APP_FIELDS = ['name', 'default_term', 'terminal_grid', 'transport', 'ui'];
+const MUTABLE_APP_FIELDS = ['name', 'default_term', 'font_faces', 'terminal_grid', 'transport', 'ui'];
 
 router.put('/', (req: Request, res: Response) => {
   try {
@@ -57,6 +118,7 @@ router.put('/', (req: Request, res: Response) => {
         default_term: updates.default_term
           ? { ...current.app.default_term, ...updates.default_term }
           : current.app.default_term,
+        font_faces: updates.font_faces !== undefined ? updates.font_faces : current.app.font_faces,
         terminal_grid: updates.terminal_grid
           ? { ...current.app.terminal_grid, ...updates.terminal_grid }
           : current.app.terminal_grid,
@@ -81,16 +143,21 @@ router.put('/', (req: Request, res: Response) => {
         res.status(400).json({ error: (err as Error).message });
         return;
       }
+      if ((err as Error).message === FONT_FACE_CONFIG_ERROR) {
+        res.status(400).json({ error: (err as Error).message });
+        return;
+      }
       throw err;
     }
-    const persisted = {
+    const persisted: AppConfig = {
       app: {
         ...merged.app,
         default_term: normalized.app.default_term,
+        font_faces: normalized.app.font_faces,
       },
     };
     persistence.saveApp(persisted);
-    res.json(normalizeAppConfig(appConfigWithEffectiveTerminalGridLimits(persisted)));
+    res.json(withFontFaceUrls(normalizeAppConfig(appConfigWithEffectiveTerminalGridLimits(persisted))));
   } catch {
     res.status(500).json({ error: 'Failed to save config' });
   }

--- a/webmux/backend/src/api/config.ts
+++ b/webmux/backend/src/api/config.ts
@@ -47,9 +47,14 @@ function configuredFontFile(index: number): { file: string; contentType: string 
   const app = normalizeAppConfig(appConfigWithEffectiveTerminalGridLimits(persistence.loadApp()));
   const face = app.app.font_faces?.[index];
   if (!face) return null;
-  const file = path.resolve(appConfigDir(), face.source);
+  const configDir = appConfigDir();
+  const file = fs.realpathSync(path.resolve(configDir, face.source));
+  const relativeFile = path.relative(configDir, file);
+  if (!relativeFile || relativeFile === '..' || relativeFile.startsWith(`..${path.sep}`) || path.isAbsolute(relativeFile)) {
+    return null;
+  }
   const contentType = FONT_CONTENT_TYPES[path.extname(file).toLowerCase()];
-  if (!contentType) return null;
+  if (!contentType || !fs.statSync(file).isFile()) return null;
   return { file, contentType };
 }
 
@@ -74,7 +79,7 @@ router.get('/fonts/:index', (req: Request, res: Response) => {
   }
   try {
     const fontFile = configuredFontFile(index);
-    if (!fontFile || !fs.existsSync(fontFile.file) || !fs.statSync(fontFile.file).isFile()) {
+    if (!fontFile) {
       res.status(404).json({ error: 'Font not found' });
       return;
     }

--- a/webmux/backend/src/index.ts
+++ b/webmux/backend/src/index.ts
@@ -44,6 +44,7 @@ async function main(): Promise<void> {
         secure_mode: false,
         trusted_http_allowed: true,
         default_term: { cols: 80, rows: 24, font_size: 14, font_family: DEFAULT_TERMINAL_FONT_FAMILY },
+        font_faces: [],
         terminal_grid: { max_cols: null, max_rows: null },
         ui: { default_pane: 'terminals', host_switcher: { enabled: false, suffixes: [], hosts: [] } },
         agents: { enabled: false, combined_pane: true, disable_in_multi_user_mode: true, definitions: [] },

--- a/webmux/backend/src/services/appConfig.ts
+++ b/webmux/backend/src/services/appConfig.ts
@@ -3,6 +3,7 @@ import type {
   AgentDefinition,
   AgentDefinitionConfig,
   AppConfig,
+  AppFontFaceConfig,
   HostSwitcherConfig,
   NormalizedAgentsConfig,
   WorkspaceName,
@@ -10,7 +11,10 @@ import type {
 
 const AGENT_ID_RE = /^[a-z][a-z0-9_-]{0,63}$/;
 const TMUX_SOCKET_RE = /^[a-zA-Z0-9_.-]+$/;
-export const DEFAULT_TERMINAL_FONT_FAMILY = 'Consolas, Menlo, "DejaVu Sans Mono", monospace';
+export const DEFAULT_TERMINAL_FONT_FAMILY = 'ui-monospace, "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", "DejaVu Sans Mono", monospace';
+export const FONT_FACE_CONFIG_ERROR = 'Invalid app.font_faces';
+const SUPPORTED_FONT_EXTENSIONS = new Set(['.otf', '.ttf', '.woff', '.woff2']);
+const FONT_DISPLAY_VALUES = new Set(['auto', 'block', 'swap', 'fallback', 'optional']);
 const GENERIC_FONT_FAMILIES = new Set([
   'serif',
   'sans-serif',
@@ -90,6 +94,85 @@ function normalizeFontFamily(value: unknown): string {
     throw new Error('Invalid app.default_term.font_family');
   }
   return normalized;
+}
+
+function stripMatchingQuotes(value: string): string {
+  const quote = value[0];
+  if ((quote === '"' || quote === "'") && value[value.length - 1] === quote) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function normalizeFontFaceFamily(value: unknown): string {
+  const family = stringOrDefault(value, '');
+  if (!family || family.length > 128 || /[\0\r\n;{}\\]/.test(family)) {
+    throw new Error(FONT_FACE_CONFIG_ERROR);
+  }
+  return stripMatchingQuotes(normalizeFontFamilyPart(family));
+}
+
+function normalizeFontFaceSource(value: unknown): string {
+  const source = stringOrDefault(value, '');
+  if (
+    !source ||
+    source.length > 512 ||
+    path.isAbsolute(source) ||
+    /[\0\r\n]/.test(source) ||
+    /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(source)
+  ) {
+    throw new Error(FONT_FACE_CONFIG_ERROR);
+  }
+  const extension = path.extname(source).toLowerCase();
+  if (!SUPPORTED_FONT_EXTENSIONS.has(extension)) {
+    throw new Error(FONT_FACE_CONFIG_ERROR);
+  }
+  return source;
+}
+
+function normalizeFontFaceWeight(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const weight = typeof value === 'number' ? String(value) : stringOrDefault(value, '');
+  if (/^(normal|bold|[1-9]00)$/.test(weight)) return weight;
+  throw new Error(FONT_FACE_CONFIG_ERROR);
+}
+
+function normalizeFontFaceStyle(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const style = stringOrDefault(value, '').toLowerCase();
+  if (style === 'normal' || style === 'italic' || style === 'oblique') return style;
+  throw new Error(FONT_FACE_CONFIG_ERROR);
+}
+
+function normalizeFontFaceDisplay(value: unknown): AppFontFaceConfig['display'] | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const display = stringOrDefault(value, '').toLowerCase();
+  if (FONT_DISPLAY_VALUES.has(display)) return display as AppFontFaceConfig['display'];
+  throw new Error(FONT_FACE_CONFIG_ERROR);
+}
+
+export function normalizeFontFaces(value: unknown): AppFontFaceConfig[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value) || value.length > 32) {
+    throw new Error(FONT_FACE_CONFIG_ERROR);
+  }
+  return value.map(face => {
+    if (!face || typeof face !== 'object') {
+      throw new Error(FONT_FACE_CONFIG_ERROR);
+    }
+    const raw = face as Record<string, unknown>;
+    const normalized: AppFontFaceConfig = {
+      family: normalizeFontFaceFamily(raw.family),
+      source: normalizeFontFaceSource(raw.source),
+    };
+    const weight = normalizeFontFaceWeight(raw.weight);
+    const style = normalizeFontFaceStyle(raw.style);
+    const display = normalizeFontFaceDisplay(raw.display);
+    if (weight) normalized.weight = weight;
+    if (style) normalized.style = style;
+    if (display) normalized.display = display;
+    return normalized;
+  });
 }
 
 function normalizeWorkspace(value: unknown, id: string): WorkspaceName {
@@ -181,6 +264,7 @@ export function normalizeAppConfig(config: AppConfig): AppConfig {
         ...config.app.default_term,
         font_family: normalizeFontFamily(config.app.default_term?.font_family),
       },
+      font_faces: normalizeFontFaces(config.app.font_faces),
       ui: {
         default_pane: stringOrDefault(ui.default_pane, 'terminals'),
         host_switcher: normalizeHostSwitcher(ui.host_switcher),

--- a/webmux/backend/src/services/appConfig.ts
+++ b/webmux/backend/src/services/appConfig.ts
@@ -114,10 +114,12 @@ function normalizeFontFaceFamily(value: unknown): string {
 
 function normalizeFontFaceSource(value: unknown): string {
   const source = stringOrDefault(value, '');
+  const pathSegments = source.split(/[\\/]/);
   if (
     !source ||
     source.length > 512 ||
     path.isAbsolute(source) ||
+    pathSegments.includes('..') ||
     /[\0\r\n]/.test(source) ||
     /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(source)
   ) {

--- a/webmux/backend/src/types/index.ts
+++ b/webmux/backend/src/types/index.ts
@@ -12,6 +12,7 @@ export interface AppConfig {
       font_size: number;
       font_family?: string;
     };
+    font_faces?: AppFontFaceConfig[];
     terminal_grid?: {
       max_cols?: number | null;
       max_rows?: number | null;
@@ -33,6 +34,16 @@ export interface AppConfig {
     // Populated from WEBMUX_EXEC_COMMAND env var at runtime; not persisted to app.yaml.
     exec_command?: string;
   };
+}
+
+export interface AppFontFaceConfig {
+  family: string;
+  source: string;
+  weight?: string | number;
+  style?: string;
+  display?: 'auto' | 'block' | 'swap' | 'fallback' | 'optional';
+  // Populated in API responses; not persisted to app.yaml.
+  url?: string;
 }
 
 export interface HostSwitcherConfig {

--- a/webmux/config.defaults/app.yaml
+++ b/webmux/config.defaults/app.yaml
@@ -9,7 +9,8 @@ app:
     cols: 80
     rows: 24
     font_size: 14
-    font_family: Consolas, Menlo, "DejaVu Sans Mono", monospace
+    font_family: ui-monospace, "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", "DejaVu Sans Mono", monospace
+  font_faces: []
   terminal_grid:
     max_cols: null
     max_rows: null

--- a/webmux/examples/agent-views/app.yaml
+++ b/webmux/examples/agent-views/app.yaml
@@ -9,7 +9,8 @@ app:
     cols: 120
     rows: 40
     font_size: 14
-    font_family: Consolas, Menlo, "DejaVu Sans Mono", monospace
+    font_family: ui-monospace, "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", "DejaVu Sans Mono", monospace
+  font_faces: []
   terminal_grid:
     max_cols: null
     max_rows: null

--- a/webmux/frontend/index.html
+++ b/webmux/frontend/index.html
@@ -8,7 +8,7 @@
     <style>
       *, *::before, *::after { box-sizing: border-box; }
       :root {
-        --webmux-mono-font: Consolas, Menlo, "DejaVu Sans Mono", monospace;
+        --webmux-mono-font: ui-monospace, "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", "DejaVu Sans Mono", monospace;
       }
       html, body, #root {
         margin: 0;

--- a/webmux/frontend/src/App.tsx
+++ b/webmux/frontend/src/App.tsx
@@ -10,11 +10,12 @@ import { RegisterDialog } from './components/RegisterDialog';
 import { InputBroadcastProvider } from './contexts/InputBroadcastContext';
 import { WorkspacePaneProvider, useWorkspacePane, type WorkspacePane } from './contexts/WorkspacePaneContext';
 import { api } from './utils/api';
-import type { AgentDefinition, AgentsConfig, HostSwitcherConfig, NamedTheme } from './types';
+import type { AgentDefinition, AgentsConfig, AppFontFaceConfig, HostSwitcherConfig, NamedTheme } from './types';
 import { loadBundledThemes, loadGlobalTheme, saveGlobalTheme } from './utils/themes';
 import {
   DEFAULT_TERMINAL_FONT_FAMILY,
   TERMINAL_FONT_CSS_VARIABLE,
+  installConfiguredFontFaces,
   normalizeTerminalFontFamily,
 } from './utils/terminalFont';
 
@@ -249,6 +250,7 @@ export default function App() {
   const [defaultPane, setDefaultPane] = useState<WorkspacePane>('terminals');
   const [agentConfig, setAgentConfig] = useState<AgentsConfig>(DEFAULT_AGENT_CONFIG);
   const [hostSwitcher, setHostSwitcher] = useState<HostSwitcherConfig>(DEFAULT_HOST_SWITCHER);
+  const [fontFaces, setFontFaces] = useState<AppFontFaceConfig[]>([]);
 
   const currentUser = useMemo(() => auth.isAuthenticated ? parseTokenUser() : null, [auth.isAuthenticated]);
 
@@ -270,6 +272,7 @@ export default function App() {
       setDefaultPane(config.app.ui?.default_pane ?? 'terminals');
       setAgentConfig(config.app.agents ?? DEFAULT_AGENT_CONFIG);
       setHostSwitcher(config.app.ui?.host_switcher ?? DEFAULT_HOST_SWITCHER);
+      setFontFaces(config.app.font_faces ?? []);
     }).catch(() => {});
     return () => { cancelled = true; };
   }, [auth.isAuthenticated, auth.isLoading]);
@@ -281,6 +284,10 @@ export default function App() {
   useEffect(() => {
     document.documentElement.style.setProperty(TERMINAL_FONT_CSS_VARIABLE, fontFamily);
   }, [fontFamily]);
+
+  useEffect(() => {
+    installConfiguredFontFaces(fontFaces).catch(() => {});
+  }, [fontFaces]);
 
   const handleGlobalThemeChange = useCallback((name: string | null) => {
     setGlobalTheme(name);

--- a/webmux/frontend/src/components/Terminal.tsx
+++ b/webmux/frontend/src/components/Terminal.tsx
@@ -7,7 +7,7 @@ import '@xterm/xterm/css/xterm.css';
 import type { WebSocketMessage, ConnectionState, TerminalTheme } from '../types';
 import { useWebSocket } from '../hooks/useWebSocket';
 import { useInputBroadcast } from '../contexts/InputBroadcastContext';
-import { normalizeTerminalFontFamily } from '../utils/terminalFont';
+import { TERMINAL_FONTS_LOADED_EVENT, loadTerminalFontFamily, normalizeTerminalFontFamily } from '../utils/terminalFont';
 
 export const DEFAULT_TERMINAL_THEME: TerminalTheme = {
   background: '#0d0d1a',
@@ -165,9 +165,10 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
   useEffect(() => {
     if (!containerRef.current) return;
 
+    const normalizedFontFamily = normalizeTerminalFontFamily(fontFamily);
     const term = new XTerm({
       theme: { ...DEFAULT_TERMINAL_THEME, ...(theme || {}) },
-      fontFamily: normalizeTerminalFontFamily(fontFamily),
+      fontFamily: normalizedFontFamily,
       fontSize,
       cursorBlink: true,
       macOptionIsMeta: /Mac|iPhone|iPad/.test(navigator.platform),
@@ -192,6 +193,11 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
     termRef.current = term;
     fitAddonRef.current = fitAddon;
     searchAddonRef.current = searchAddon;
+    void loadTerminalFontFamily(normalizedFontFamily, fontSize).then(() => {
+      if (termRef.current !== term) return;
+      fitAddon.fit();
+      term.refresh(0, Math.max(0, term.rows - 1));
+    });
     searchAddon.onDidChangeResults(({ resultIndex, resultCount }) => {
       setSearchIndex(resultIndex);
       setSearchCount(resultCount);
@@ -260,11 +266,36 @@ export const Terminal = forwardRef<TerminalHandle, TerminalProps>(function Termi
 
   // Update font settings
   useEffect(() => {
-    if (termRef.current) {
-      termRef.current.options.fontSize = fontSize;
-      termRef.current.options.fontFamily = normalizeTerminalFontFamily(fontFamily);
+    const term = termRef.current;
+    if (!term) return;
+
+    const normalizedFontFamily = normalizeTerminalFontFamily(fontFamily);
+    let cancelled = false;
+    term.options.fontSize = fontSize;
+    term.options.fontFamily = normalizedFontFamily;
+    fitAddonRef.current?.fit();
+
+    void loadTerminalFontFamily(normalizedFontFamily, fontSize).then(() => {
+      if (cancelled || termRef.current !== term) return;
       fitAddonRef.current?.fit();
-    }
+      term.refresh(0, Math.max(0, term.rows - 1));
+    });
+
+    return () => { cancelled = true; };
+  }, [fontFamily, fontSize]);
+
+  useEffect(() => {
+    const refreshFontMetrics = () => {
+      const term = termRef.current;
+      if (!term) return;
+      void loadTerminalFontFamily(fontFamily, fontSize).then(() => {
+        if (termRef.current !== term) return;
+        fitAddonRef.current?.fit();
+        term.refresh(0, Math.max(0, term.rows - 1));
+      });
+    };
+    window.addEventListener(TERMINAL_FONTS_LOADED_EVENT, refreshFontMetrics);
+    return () => window.removeEventListener(TERMINAL_FONTS_LOADED_EVENT, refreshFontMetrics);
   }, [fontFamily, fontSize]);
 
   // Apply theme changes without tearing down the terminal (preserves scrollback).

--- a/webmux/frontend/src/types/index.ts
+++ b/webmux/frontend/src/types/index.ts
@@ -154,6 +154,15 @@ export interface HostSwitcherConfig {
   hosts: HostSwitcherHost[];
 }
 
+export interface AppFontFaceConfig {
+  family: string;
+  source: string;
+  weight?: string | number;
+  style?: string;
+  display?: 'auto' | 'block' | 'swap' | 'fallback' | 'optional';
+  url?: string;
+}
+
 export interface KeyEntry {
   id: string;
   type: string;
@@ -175,6 +184,7 @@ export interface AppConfig {
       font_size: number;
       font_family?: string;
     };
+    font_faces?: AppFontFaceConfig[];
     terminal_grid?: {
       max_cols?: number | null;
       max_rows?: number | null;

--- a/webmux/frontend/src/utils/terminalFont.ts
+++ b/webmux/frontend/src/utils/terminalFont.ts
@@ -1,7 +1,79 @@
-export const DEFAULT_TERMINAL_FONT_FAMILY = 'Consolas, Menlo, "DejaVu Sans Mono", monospace';
+import type { AppFontFaceConfig } from '../types';
+
+export const DEFAULT_TERMINAL_FONT_FAMILY = 'ui-monospace, "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", "DejaVu Sans Mono", monospace';
 export const TERMINAL_FONT_CSS_VARIABLE = '--webmux-mono-font';
+export const TERMINAL_FONTS_LOADED_EVENT = 'webmux:terminal-fonts-loaded';
+
+const installedFontFaces = new Set<string>();
 
 export function normalizeTerminalFontFamily(fontFamily: string | undefined | null): string {
   const trimmed = fontFamily?.trim();
   return trimmed || DEFAULT_TERMINAL_FONT_FAMILY;
+}
+
+function authHeaders(): HeadersInit {
+  const token = localStorage.getItem('webmux_token');
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+function fontFaceKey(face: AppFontFaceConfig): string {
+  return [
+    face.family,
+    face.url,
+    face.source,
+    face.weight ?? '',
+    face.style ?? '',
+    face.display ?? '',
+  ].join('\0');
+}
+
+export async function installConfiguredFontFaces(fontFaces: AppFontFaceConfig[] | undefined | null): Promise<void> {
+  if (
+    typeof document === 'undefined' ||
+    !('fonts' in document) ||
+    typeof FontFace === 'undefined' ||
+    !Array.isArray(fontFaces)
+  ) {
+    return;
+  }
+
+  let loadedAny = false;
+  await Promise.all(fontFaces.map(async face => {
+    if (!face.url) return;
+    const key = fontFaceKey(face);
+    if (installedFontFaces.has(key)) return;
+
+    try {
+      const response = await fetch(face.url, { headers: authHeaders() });
+      if (!response.ok) return;
+      const fontData = await response.arrayBuffer();
+      const fontFace = new FontFace(face.family, fontData, {
+        weight: String(face.weight ?? '400'),
+        style: face.style ?? 'normal',
+        display: face.display ?? 'swap',
+      });
+      const loaded = await fontFace.load();
+      document.fonts.add(loaded);
+      installedFontFaces.add(key);
+      loadedAny = true;
+    } catch {
+      // A bad custom font should not prevent the configured fallback stack from rendering.
+    }
+  }));
+
+  if (loadedAny) {
+    window.dispatchEvent(new Event(TERMINAL_FONTS_LOADED_EVENT));
+  }
+}
+
+export async function loadTerminalFontFamily(fontFamily: string | undefined | null, fontSize: number): Promise<void> {
+  if (typeof document === 'undefined' || !('fonts' in document)) return;
+
+  try {
+    const normalizedFontFamily = normalizeTerminalFontFamily(fontFamily);
+    await document.fonts.load(`${fontSize}px ${normalizedFontFamily}`);
+    await document.fonts.ready;
+  } catch {
+    // Invalid or unavailable font stacks should still fall through to browser fallback fonts.
+  }
 }


### PR DESCRIPTION
## Summary
- add app.font_faces for config-directed local font files
- serve configured font files through authenticated same-origin /api/config/fonts/:index routes
- load configured fonts with FontFace before refreshing/refitting terminals
- document comma-separated font stacks and hosted font-face config

## Tests
- npm run test --workspace=backend -- --runTestsByPath ../../tests/backend/apiRoutes.test.ts
- npm run test --workspace=frontend -- App.test.tsx
- npm run typecheck
- npm run build
- npm run lint