### PR TITLE
fix: queue WebSocket sends until OPEN to fix lost initial terminal resize

### DIFF
--- a/tests/frontend/useWebSocket.test.ts
+++ b/tests/frontend/useWebSocket.test.ts
@@ -8,11 +8,14 @@ vi.mock('@frontend/utils/api', () => ({
 
 // Minimal WebSocket mock
 class MockWebSocket {
+  static CONNECTING = 0;
   static OPEN = 1;
   static instances: MockWebSocket[] = [];
 
   url: string;
-  readyState = MockWebSocket.OPEN;
+  // Real WebSockets start CONNECTING and only reach OPEN once the handshake
+  // completes — matches that here so tests can exercise the pre-open window.
+  readyState = MockWebSocket.CONNECTING;
   onopen: (() => void) | null = null;
   onclose: ((event: { code: number; reason: string }) => void) | null = null;
   onerror: ((e: unknown) => void) | null = null;
@@ -37,7 +40,10 @@ class MockWebSocket {
   }
 
   // Helpers for tests
-  simulateOpen() { this.onopen?.(); }
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
   simulateClose(code = 1006, reason = '') { this.onclose?.({ code, reason }); }
   simulateMessage(data: object) { this.onmessage?.({ data: JSON.stringify(data) }); }
 }
@@ -118,6 +124,66 @@ describe('useWebSocket', () => {
     expect(MockWebSocket.instances[0].sentMessages).toEqual([
       JSON.stringify({ type: 'input', data: 'test' }),
     ]);
+  });
+
+  it('queues a message sent before OPEN and flushes it once the connection opens', async () => {
+    const useWebSocket = await importHook();
+    const { result } = renderHook(() =>
+      useWebSocket({ sessionId: 's1', onMessage: vi.fn() })
+    );
+    const ws = MockWebSocket.instances[0];
+    expect(ws.readyState).toBe(MockWebSocket.CONNECTING);
+
+    // e.g. the terminal's initial fitAddon.fit() firing a resize before the
+    // WebSocket handshake has completed — must not be silently dropped.
+    act(() => result.current.send({ type: 'resize', cols: 100, rows: 44 }));
+    expect(ws.sentMessages).toEqual([]);
+
+    act(() => ws.simulateOpen());
+    expect(ws.sentMessages).toEqual([
+      JSON.stringify({ type: 'resize', cols: 100, rows: 44 }),
+    ]);
+  });
+
+  it('preserves order when multiple messages are queued before OPEN', async () => {
+    const useWebSocket = await importHook();
+    const { result } = renderHook(() =>
+      useWebSocket({ sessionId: 's1', onMessage: vi.fn() })
+    );
+    const ws = MockWebSocket.instances[0];
+
+    act(() => {
+      result.current.send({ type: 'resize', cols: 80, rows: 24 });
+      result.current.send({ type: 'resize', cols: 100, rows: 44 });
+      result.current.send({ type: 'input', data: 'ls\n' });
+    });
+    expect(ws.sentMessages).toEqual([]);
+
+    act(() => ws.simulateOpen());
+    expect(ws.sentMessages).toEqual([
+      JSON.stringify({ type: 'resize', cols: 80, rows: 24 }),
+      JSON.stringify({ type: 'resize', cols: 100, rows: 44 }),
+      JSON.stringify({ type: 'input', data: 'ls\n' }),
+    ]);
+  });
+
+  it('does not replay queued messages into a later connection after unmount', async () => {
+    const useWebSocket = await importHook();
+    const { result, unmount } = renderHook(() =>
+      useWebSocket({ sessionId: 's1', onMessage: vi.fn() })
+    );
+    const ws = MockWebSocket.instances[0];
+
+    act(() => result.current.send({ type: 'resize', cols: 100, rows: 44 }));
+    expect(ws.sentMessages).toEqual([]);
+
+    unmount();
+
+    // A torn-down component's pending queue must not leak into whatever
+    // socket a future mount for this session opens next.
+    const ws2 = new MockWebSocket('ws://localhost/api/term/s1');
+    act(() => ws2.simulateOpen());
+    expect(ws2.sentMessages).toEqual([]);
   });
 
   it('calls onClose and reconnects with backoff on abnormal close', async () => {

--- a/webmux/frontend/src/hooks/useWebSocket.ts
+++ b/webmux/frontend/src/hooks/useWebSocket.ts
@@ -24,6 +24,11 @@ export function useWebSocket(options: UseWebSocketOptions): WebSocketHandle {
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const attemptRef = useRef(0);
   const closedRef = useRef(false);
+  // Messages sent before the socket reaches OPEN (e.g. the initial terminal
+  // fit/resize, which fires synchronously on mount while the handshake is
+  // still in flight) are queued here and flushed in order once onopen fires,
+  // instead of being silently dropped.
+  const pendingRef = useRef<WebSocketMessage[]>([]);
 
   const { sessionId, onMessage, onOpen, onClose, onUnauthorized } = options;
 
@@ -60,6 +65,11 @@ export function useWebSocket(options: UseWebSocketOptions): WebSocketHandle {
 
       ws.onopen = () => {
         attemptRef.current = 0;
+        const queued = pendingRef.current;
+        pendingRef.current = [];
+        for (const msg of queued) {
+          ws.send(JSON.stringify(msg));
+        }
         onOpenRef.current?.();
       };
 
@@ -101,12 +111,17 @@ export function useWebSocket(options: UseWebSocketOptions): WebSocketHandle {
       }
       wsRef.current?.close(1000);
       wsRef.current = null;
+      // Drop anything still queued so a torn-down component can't leak
+      // sends into a future socket (new session, or a remount).
+      pendingRef.current = [];
     };
   }, [sessionId]);
 
   const send = useCallback((msg: WebSocketMessage) => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {
       wsRef.current.send(JSON.stringify(msg));
+    } else if (wsRef.current?.readyState === WebSocket.CONNECTING) {
+      pendingRef.current.push(msg);
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- `useWebSocket`'s `send()` silently dropped any message sent while the socket was still `CONNECTING`. `Terminal.tsx` fits the terminal to its container and fires an `onResize` → `send({type:'resize', ...})` synchronously right after mount, before the WebSocket handshake usually completes, so that first resize is lost.
- Effect: the backend session keeps its creation-time default (`cols: req.cols || 80, rows: req.rows || 24`), so the remote PTY can stay at 80x24 indefinitely even though the browser-side xterm renders at the real fitted size, until some other event happens to change the container size again.
- Fix: buffer outgoing messages in a ref-backed queue while the socket is `CONNECTING`, flush them in order on `onopen` before the caller's `onOpen` callback fires. The queue is cleared on effect cleanup so a torn-down component can't leak sends into a later connection.

## Test plan
- [x] Extended `tests/frontend/useWebSocket.test.ts`: fixed the mock socket to start at `CONNECTING` (it previously defaulted to `OPEN`, which couldn't reproduce the race), added cases for queued send flushed on open, multi-message order preserved, and no leak into a later connection after unmount.
- [x] `make test-unit` green: backend 227/227, frontend 171/171 (168 existing + 3 new).
- [x] Reproduced the bug live before the fix (`stty` on the remote PTY showed 24x80 while the browser had fit to a much larger container) and confirmed the fix addresses the root cause via the new tests.