### PR TITLE
Release v1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [1.3.3] - 2026-08-27
+
+### Added
+- show a prominent refresh action in disconnected terminal, VNC, and RDP windows
+- add GitHub issue forms and a pull request template
+
+### Changed
+- replace beads task management with GitHub Issues and pull requests
+
 ## [1.3.2] - 2026-08-25
 
 ### Added

--- a/webmux/backend/package.json
+++ b/webmux/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webmux-backend",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "scripts": {
     "build": "tsc",

--- a/webmux/frontend/package.json
+++ b/webmux/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webmux-frontend",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/webmux/package-lock.json
+++ b/webmux/package-lock.json
@@ -17,7 +17,7 @@
     },
     "backend": {
       "name": "webmux-backend",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dependencies": {
         "argon2": "^0.31.2",
         "chokidar": "^3.6.0",
@@ -52,7 +52,7 @@
     },
     "frontend": {
       "name": "webmux-frontend",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "dependencies": {
         "@novnc/novnc": "^1.6.0",
         "@xterm/addon-fit": "^0.10.0",


### PR DESCRIPTION
## Summary

- Bump frontend and backend package versions to 1.3.3.
- Document the disconnected-window refresh action.
- Document the migration from beads to GitHub Issues and pull requests.

## Validation

- `make test`: 227 backend, 168 frontend, and 7 E2E tests passed.
- `make lint`: passes with 11 existing warnings.
- `git diff --check`: passes.

Closes #29
