### PR TITLE
Refresh project documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions
 
-This project uses GitHub Issues for task tracking and pull requests for changes.
+Public work enters through GitHub Issues and pull requests. Maintainers use [mac](https://github.com/jordanhubbard/mac) for internal task tracking and work dispatch. This repository does not use beads.
 
 ## Quick Reference
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Documentation
+- refresh feature, architecture, development, and contributor documentation
+- point the WebMux origin story at the successor `mac` project
+
 ## [1.3.3] - 2026-08-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Documentation
 - refresh feature, architecture, development, and contributor documentation
+- split macOS, Linux, and Windows setup into focused platform guides
 - point the WebMux origin story at the successor `mac` project
 
 ## [1.3.3] - 2026-08-27

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ When a skill applies to the current task, use it. Key skills:
 
 - The application source lives under `webmux/` (backend + frontend workspaces).
 - Backend: Express + ws + node-pty (TypeScript). Frontend: React + xterm.js (TypeScript, Vite).
-- Configuration is YAML-based in `webmux/config/`.
+- Runtime configuration is YAML-based under `WEBMUX_HOME/config/` (default `~/.config/webmux/config/`); `webmux/config.defaults/` contains first-run templates.
 - The top-level `Makefile` delegates to `npm` scripts inside `webmux/`.
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ When a skill applies to the current task, use it. Key skills:
 
 ## GitHub Workflow
 
-This project uses GitHub Issues for task tracking and pull requests for changes.
+Public work enters through GitHub Issues and pull requests. Maintainers use [mac](https://github.com/jordanhubbard/mac) for internal task tracking and work dispatch. This repository does not use beads.
 
 ### Quick Reference
 

--- a/README-Linux.md
+++ b/README-Linux.md
@@ -1,0 +1,76 @@
+# Running WebMux on Linux
+
+WebMux runs natively on Linux using Unix pseudoterminals through `node-pty`. The repository Makefile can build the application, run it directly, or install it as a systemd user service.
+
+## Prerequisites
+
+- A supported 64-bit or ARM64 Linux distribution
+- Node.js 20 or newer
+- Git and OpenSSH Client
+- A C/C++ toolchain and Python if npm must compile a native dependency
+
+On Debian or Ubuntu, install the common prerequisites with:
+
+```bash
+sudo apt update
+sudo apt install git openssh-client build-essential python3
+```
+
+Install Node.js 20 or newer using your distribution packages, NodeSource, or another trusted Node.js distribution. Verify it before building:
+
+```bash
+node --version
+ssh -V
+```
+
+Optional packages include `sshpass` for password-based SSH, `mosh` for mosh transport, `tmux` for agent views, and `guacd` for RDP:
+
+```bash
+sudo apt install sshpass mosh tmux guacd
+```
+
+Package names vary by distribution. SSH keys are preferred over `sshpass`. VNC support does not require a separate local proxy.
+
+## Build and Run
+
+```bash
+git clone https://github.com/jordanhubbard/webmux.git
+cd webmux
+make
+make start
+```
+
+Open `http://localhost:8080`. Runtime configuration and state default to `~/.config/webmux/`.
+
+## Install as a Service
+
+```bash
+make install
+make status
+```
+
+This installs `~/.config/systemd/user/webmux.service`, enables it, and starts WebMux as the installing user so it can access that user's SSH configuration and keys.
+
+Use the repository Makefile for service management:
+
+```bash
+make restart
+make stop
+make uninstall
+```
+
+To start the user service during boot without an interactive login:
+
+```bash
+loginctl enable-linger "$USER"
+```
+
+Logs are written to `~/.config/webmux/logs/webmux.log` unless `WEBMUX_HOME` is overridden.
+
+## Platform Notes
+
+- `make check-guacd` reports whether the RDP proxy is installed.
+- Package and firewall commands differ across distributions; expose only the configured WebMux port.
+- When exposing WebMux beyond the local host, use local authentication, set a strong `JWT_SECRET`, configure TLS, and apply appropriate firewall or network controls.
+
+Return to the [main README](README.md).

--- a/README-Windows.md
+++ b/README-Windows.md
@@ -1,0 +1,92 @@
+# Running WebMux on Windows
+
+WebMux runs natively on modern Windows using ConPTY through `node-pty`. The backend resolves `ssh.exe` from `PATH`, uses `cmd.exe` for local command templates and scratch shells, and stores runtime state under the hosting user's profile by default.
+
+## Prerequisites
+
+1. A current 64-bit or ARM64 Windows release with ConPTY support. Installing the Windows service also requires .NET Framework 4.6.1 or newer, included with supported Windows releases.
+2. Node.js 20 or newer.
+3. Microsoft OpenSSH Client, with `ssh.exe` available through `PATH`.
+4. Git when installing from a source checkout.
+
+Install the common prerequisites from an elevated PowerShell prompt:
+
+```powershell
+winget install OpenJS.NodeJS.LTS
+winget install Git.Git
+Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
+```
+
+Open a new PowerShell window and verify the installation:
+
+```powershell
+node --version
+ssh -V
+git --version
+```
+
+Published dependencies normally provide prebuilt Windows binaries. If npm must compile `node-pty` or `argon2`, install Visual Studio Build Tools with the **Desktop development with C++** workload and rerun `npm ci`.
+
+## Build and Run
+
+```powershell
+git clone https://github.com/jordanhubbard/webmux.git
+cd webmux\webmux
+npm ci
+npm run build
+npm start
+```
+
+Open `http://localhost:8080`. Runtime configuration and state default to `%USERPROFILE%\.config\webmux`.
+
+Override runtime settings for the current PowerShell session when needed:
+
+```powershell
+$env:WEBMUX_HOME = 'D:\WebMuxData'
+$env:HTTP_PORT = '8080'
+$env:JWT_SECRET = '<strong-random-secret>'
+npm start
+```
+
+## Install as a Service
+
+From an elevated PowerShell window in the inner `webmux` directory:
+
+```powershell
+npm run service:install
+npm run service:status
+```
+
+The installer prompts for the current Windows account's password, grants that account the **Log on as a service** right, configures automatic delayed startup and failure recovery, and starts WebMux. Running under that account preserves access to its SSH keys and known-hosts data. The password is passed to Windows during registration and is not retained in WebMux's service configuration.
+
+Manage the service with:
+
+```powershell
+npm run service:stop
+npm run service:start
+npm run service:restart
+npm run service:uninstall
+```
+
+The installer downloads and checksum-verifies the stable [WinSW 2.12.0 service wrapper](https://github.com/winsw/winsw/releases/tag/v2.12.0) under `%ProgramData%\WebMux`. The first service installation therefore requires access to GitHub. Service output is written under `%WEBMUX_HOME%\logs`; uninstalling preserves runtime data and logs.
+
+For an isolated test installation that does not need user SSH credentials, use `npm run service:install -- -LocalSystem`. LocalSystem cannot use the interactive user's SSH keys or known-hosts file and is not recommended for normal hosting.
+
+## Network Access
+
+For access from other machines, allow the selected port through Windows Defender Firewall and keep authentication and TLS appropriate for the network. For example, from elevated PowerShell:
+
+```powershell
+New-NetFirewallRule -DisplayName 'WebMux 8080' -Direction Inbound -Protocol TCP -LocalPort 8080 -Action Allow
+```
+
+## Platform Notes
+
+- Key-based OpenSSH sessions are the recommended native Windows configuration.
+- Password-based remote SSH requires `sshpass`, which is not normally available on native Windows.
+- Mosh requires compatible `mosh` executables and remains optional.
+- tmux-backed agent views require tmux and are intended for macOS/Linux hosts.
+- RDP support requires a reachable `guacd`; native Windows does not include it.
+- The repository-level `make` commands are macOS/Linux conveniences. Use npm and PowerShell service commands on Windows.
+
+Return to the [main README](README.md).

--- a/README-macOS.md
+++ b/README-macOS.md
@@ -1,0 +1,67 @@
+# Running WebMux on macOS
+
+WebMux runs natively on macOS using Unix pseudoterminals through `node-pty`. The repository Makefile can build the application, run it directly, or install it as a per-user launchd service.
+
+## Prerequisites
+
+- A currently supported macOS release
+- Node.js 20 or newer
+- Git
+- The built-in OpenSSH client
+- Xcode Command Line Tools if npm must compile a native dependency
+
+Homebrew is a convenient way to install the required tools:
+
+```bash
+xcode-select --install
+brew install node git
+```
+
+Optional features require additional software:
+
+```bash
+brew install mosh          # mosh transport
+brew install hudochenkov/sshpass/sshpass  # password-based SSH
+brew install guacamole-server             # RDP proxy
+brew install tmux                          # agent views
+```
+
+SSH keys are preferred over `sshpass`. VNC support does not require a separate local proxy.
+
+## Build and Run
+
+```bash
+git clone https://github.com/jordanhubbard/webmux.git
+cd webmux
+make
+make start
+```
+
+Open `http://localhost:8080`. Runtime configuration and state default to `~/.config/webmux/`.
+
+## Install as a Service
+
+```bash
+make install
+make status
+```
+
+This installs `~/Library/LaunchAgents/com.webmux.server.plist`, starts WebMux, and configures launchd to start it when the user logs in. It runs as the installing user so it can access that user's SSH configuration and keys.
+
+Use the repository Makefile for service management:
+
+```bash
+make restart
+make stop
+make uninstall
+```
+
+Logs are written to `~/.config/webmux/logs/webmux.log` unless `WEBMUX_HOME` is overridden.
+
+## Platform Notes
+
+- macOS includes `ssh`, but not `sshpass`, mosh, tmux, or `guacd` by default.
+- `make check-guacd` reports whether the RDP proxy is installed.
+- To expose WebMux beyond the local host, use local authentication, set a strong `JWT_SECRET`, configure TLS, and apply appropriate host firewall or network controls.
+
+Return to the [main README](README.md).

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ A browser-based remote workspace for persistent terminal and desktop sessions. W
 - (Optional) a VNC target for VNC sessions
 - (Optional) Apache Guacamole's `guacd` for RDP sessions
 
+### Supported Platforms
+
+WebMux runs natively on all three major desktop/server platforms. Each platform guide covers prerequisites, native terminal support, service installation, and platform-specific limitations:
+
+- **macOS**: [README-macOS.md](README-macOS.md) (Unix PTYs and launchd)
+- **Linux**: [README-Linux.md](README-Linux.md) (Unix PTYs and systemd user services)
+- **Windows**: [README-Windows.md](README-Windows.md) (ConPTY and Windows Service Control Manager)
+
 ### Build and Run
 
 ```bash
@@ -59,7 +67,7 @@ WebMux will start automatically on login and auto-reconnect any persistent sessi
 make uninstall  # remove the OS service
 ```
 
-`make install` supports macOS and Linux. See [Hosting on Windows](#hosting-on-windows) for native Windows setup and startup options.
+`make install` supports macOS and Linux. Windows uses the npm service commands documented in [README-Windows.md](README-Windows.md).
 
 ### Makefile Targets
 
@@ -87,99 +95,6 @@ make start HTTP_PORT=9090
 make start AUTH_MODE=none
 make start SECURE_MODE=true JWT_SECRET=$(openssl rand -hex 32)
 ```
-
-## Hosting on Windows
-
-WebMux runs natively on modern Windows using ConPTY through `node-pty`. The backend resolves `ssh.exe` from `PATH`, uses `cmd.exe` for local command templates and scratch shells, and stores runtime state under the hosting user's profile by default.
-
-### Required software
-
-1. **64-bit or ARM64 Windows with ConPTY support.** Keep Windows current; unsupported legacy Windows releases cannot provide the required pseudoterminal API. Installing the Windows service also requires .NET Framework 4.6.1 or newer, which is included with supported Windows releases.
-2. **Node.js 20 or newer.** Install the current LTS release from [nodejs.org](https://nodejs.org/) or from an elevated PowerShell prompt:
-
-   ```powershell
-   winget install OpenJS.NodeJS.LTS
-   ```
-
-3. **Microsoft OpenSSH Client.** Check whether it is already installed:
-
-   ```powershell
-   ssh -V
-   ```
-
-   If it is missing, install the Windows capability from an elevated PowerShell prompt, then open a new terminal:
-
-   ```powershell
-   Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
-   ssh -V
-   ```
-
-   `ssh.exe` must be visible through `PATH`. WebMux resolves it to an absolute path before starting a ConPTY session.
-
-4. **Git**, when installing from a source checkout. Install it from [git-scm.com](https://git-scm.com/download/win) or with:
-
-   ```powershell
-   winget install Git.Git
-   ```
-
-The published dependencies normally provide prebuilt Windows binaries. If npm reports that it must compile `node-pty` or `argon2`, install Visual Studio Build Tools with the **Desktop development with C++** workload and rerun `npm ci`.
-
-### Install and run from PowerShell
-
-```powershell
-git clone https://github.com/jordanhubbard/webmux.git
-cd webmux\webmux
-npm ci
-npm run build
-npm start
-```
-
-Open `http://localhost:8080`. The default Windows runtime directory is `%USERPROFILE%\.config\webmux`. Override runtime settings for the current PowerShell session when needed:
-
-```powershell
-$env:WEBMUX_HOME = 'D:\WebMuxData'
-$env:HTTP_PORT = '8080'
-$env:JWT_SECRET = '<strong-random-secret>'
-npm start
-```
-
-For access from other machines, allow the selected port through Windows Defender Firewall and keep WebMux's authentication/TLS configuration appropriate for the network. For example, from elevated PowerShell:
-
-```powershell
-New-NetFirewallRule -DisplayName 'WebMux 8080' -Direction Inbound -Protocol TCP -LocalPort 8080 -Action Allow
-```
-
-### Install as a Windows service
-
-From an elevated PowerShell window in the inner `webmux` directory, install WebMux with Windows Service Control Manager:
-
-```powershell
-npm run service:install
-npm run service:status
-```
-
-The installer prompts for the current Windows account's password, grants that account the **Log on as a service** right, configures automatic delayed startup and failure recovery, and starts WebMux. Using the same account preserves access to that user's SSH keys and known-hosts data. The password is passed to Windows during registration and is not retained in WebMux's service configuration.
-
-Service commands are available for normal administration:
-
-```powershell
-npm run service:stop
-npm run service:start
-npm run service:restart
-npm run service:uninstall
-```
-
-The installer downloads the stable [WinSW 2.12.0 service wrapper](https://github.com/winsw/winsw/releases/tag/v2.12.0) into `%ProgramData%\WebMux` and verifies its SHA-256 checksum. An internet connection to GitHub is therefore required for the first installation. Service output is written under `%WEBMUX_HOME%\logs`; uninstalling preserves runtime data and logs.
-
-For an isolated test installation that does not need user SSH credentials, `npm run service:install -- -LocalSystem` is also supported. LocalSystem cannot use the interactive user's SSH keys or known-hosts file and is not recommended for normal WebMux hosting.
-
-### Windows feature notes
-
-- Key-based OpenSSH sessions are the recommended native Windows configuration.
-- Password-based remote SSH requires `sshpass`, which is not normally available on native Windows. Without it, use SSH keys.
-- Mosh requires compatible `mosh` executables and remains optional.
-- tmux-backed agent views require tmux and are intended for macOS/Linux hosts. They are disabled by default.
-- `make`, `make start`, and `make install` are macOS/Linux administration conveniences. Use the npm and PowerShell service commands above on Windows.
 
 ## Configuration
 
@@ -388,7 +303,9 @@ If Playwright does not publish a bundled Chromium build for the host OS, set `PL
 
 ## Contributing
 
-WebMux is maintained through [GitHub Issues](https://github.com/jordanhubbard/webmux/issues) and pull requests. Before opening a pull request, run `make test` and `make lint`; describe the user-visible change and link the issue it addresses.
+Public bug reports, feature requests, and proposed changes belong in [GitHub Issues](https://github.com/jordanhubbard/webmux/issues) and pull requests. The project does not use beads. Maintainers use [mac](https://github.com/jordanhubbard/mac) for internal task tracking and work dispatch; contributors do not need mac to file an issue or submit a pull request.
+
+Before opening a pull request, run `make test` and `make lint`; describe the user-visible change and link the issue it addresses.
 
 Thanks to the people who have contributed code and reviews as WebMux grew beyond its original one-person experiment, including [Isaiah Weiner](https://github.com/zoratu), [Shawn Edwards](https://github.com/lesserevil), and [Trent Nelson](https://github.com/tpn). GitHub's [contributors page](https://github.com/jordanhubbard/webmux/graphs/contributors) is the canonical, evolving record.
 
@@ -423,7 +340,7 @@ make restart      # rebuild + deliberate restart via the service manager
 
 The service auto-starts on login and restarts on crash. On startup, all persistent sessions with key/agent-based auth are automatically reconnected. Password-only sessions require manual reconnect since passwords are not persisted.
 
-Once the service is installed, `make start` / `make stop` / `make restart` are **service-manager aware**: they drive `launchctl` (macOS) or `systemctl --user` (Linux) rather than killing the process directly, so a restart is a *deliberate* restart and the service manager does not treat it as a crash. On a host where the service is *not* installed, the same targets fall back to direct pidfile-based process control for development use. On Windows, use the deliberate SCM commands `npm run service:start|stop|restart` (see the Windows hosting section).
+Once the service is installed, `make start` / `make stop` / `make restart` are **service-manager aware**: they drive `launchctl` (macOS) or `systemctl --user` (Linux) rather than killing the process directly, so a restart is a *deliberate* restart and the service manager does not treat it as a crash. On a host where the service is *not* installed, the same targets fall back to direct pidfile-based process control for development use. On Windows, use the deliberate SCM commands `npm run service:start|stop|restart` described in [README-Windows.md](README-Windows.md).
 
 On Linux, run `loginctl enable-linger $USER` to start the service at boot without logging in.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WebMux
 
-A web-native terminal multiplexer — think tmux-on-a-jump-box, but it runs in your browser. WebMux gives you a persistent, shared terminal wall: a scrollable 2D grid of live SSH (or mosh) sessions with full terminal emulation, multi-viewer presence, and input broadcast.
+A browser-based remote workspace for persistent terminal and desktop sessions. WebMux started as tmux-on-a-jump-box: a shared, scrollable wall of SSH and mosh terminals. It now also brings VNC, RDP, and optional tmux-backed coding-agent sessions into the same web interface.
 
 ## Features
 
@@ -9,17 +9,21 @@ A web-native terminal multiplexer — think tmux-on-a-jump-box, but it runs in y
 - **Full terminal emulation** — xterm.js with 256-color, clickable links, 5000-line scrollback
 - **SSH and mosh transports** — proper PTY via node-pty, with keepalive and auto-reconnect
 - **Persistent sessions** — sessions survive browser closes and server reboots; auto-reconnected on startup
+- **Remote desktop workspace** — arrange VNC and RDP sessions in a second tiled workspace, with fullscreen viewing and reconnect controls
 - **Saved hosts** — save connection profiles for one-click connect; stored with hostname, port, username, transport, and key
 - **Multi-user accounts** — multiple users with separate session collections; Argon2id password hashing
 - **Multi-viewer presence** — multiple tabs can watch the same session; click-to-focus controls who has keyboard input
 - **Type to All** — broadcast mode sends keystrokes to every open session simultaneously
 - **Keyboard terminal cycling** — `Ctrl+Shift+<` and `Ctrl+Shift+>` focus previous/next terminal tiles
+- **Workspace navigation** — switch among terminals, desktops, and configured agent views; use the minimap and minimized-session dock to navigate larger layouts
+- **Per-window controls** — rename, move, minimize, lock, theme, and control auto-scroll for individual terminal sessions or globally
 - **SSH key and password auth** — managed keys via `keys.yaml`, password-based via `sshpass`
 - **Two security modes** — local auth (Argon2id + JWT + HTTPS) or trusted mode for isolated networks
 - **OS service integration** — launchd (macOS), systemd (Linux), and Windows Service Control Manager support
 - **YAML configuration** — human-editable config in `~/.config/webmux/`, separate from the source tree
 - **Audit log** — append-only JSONL event log (logins, session lifecycle)
 - **Optional agent views** — disabled-by-default tmux-backed agent session browser with attach and scratch-shell support
+- **Session expiry handling** — visible JWT countdown and refresh controls prevent expired browser sessions from entering reconnect loops
 
 ## Quick Start
 
@@ -29,6 +33,8 @@ A web-native terminal multiplexer — think tmux-on-a-jump-box, but it runs in y
 - OpenSSH client (`ssh` on macOS/Linux, `ssh.exe` on `PATH` on Windows)
 - (Optional) `sshpass` for password-based SSH auth
 - (Optional) `mosh` on both ends for mosh transport
+- (Optional) a VNC target for VNC sessions
+- (Optional) Apache Guacamole's `guacd` for RDP sessions
 
 ### Build and Run
 
@@ -37,7 +43,9 @@ make            # install deps + build
 make start      # start in background
 ```
 
-Open `http://localhost:8080`. On first run with local auth, you'll be prompted to create an account.
+Open `http://localhost:8080`. On first run with local auth, you'll be prompted to create the first administrator account.
+
+Runtime configuration and state are created under `~/.config/webmux/` by default; the source checkout remains disposable.
 
 ### Install as a Service
 
@@ -204,6 +212,9 @@ app:
   transport:
     prefer_mosh: false
     ssh_fallback: true
+  guacd:
+    host: 127.0.0.1
+    port: 4822
 ```
 
 The `default_term` settings control every terminal tile's dimensions and fixed-width font. Each tile is rendered at a fixed pixel size derived from `cols`, `rows`, and `font_size`. `font_family` accepts a normal comma-separated CSS font-family list and is applied across terminal and monospace UI text. Multi-word family names such as `Custom Mono` are normalized to quoted CSS family names, so `Custom Mono, Monaco, monospace` is returned and saved as `"Custom Mono", Monaco, monospace`. The size values can also be adjusted live from the top bar; changes are saved back to `app.yaml` automatically.
@@ -213,6 +224,8 @@ Optional `font_faces` entries let WebMux host local font files for browser clien
 The optional `terminal_grid` settings cap the number of columns and rows available in the terminals workspace. By default both directions are unlimited. `WEBMUX_TERMINAL_GRID_MAX_COLS` and `WEBMUX_TERMINAL_GRID_MAX_ROWS` override the YAML values at runtime; set either variable to a positive integer, or to `0`/`unlimited` for no limit.
 
 Optional tmux-backed agent views are configured under `app.agents` and are disabled by default. See [Agent Views](docs/agent-views.md) and the sample config at [webmux/examples/agent-views/app.yaml](webmux/examples/agent-views/app.yaml).
+
+RDP sessions are proxied through Apache Guacamole's `guacd`; use `make check-guacd` to check the local installation. VNC sessions connect through WebMux's authenticated WebSocket proxy. Enable either protocol per saved host with its configured port.
 
 ### `auth.yaml` — Authentication
 
@@ -234,6 +247,10 @@ hosts:
     key_id: ''
     tags: [linux, build]
     mosh_allowed: false
+    vnc_enabled: false
+    vnc_port: 5900
+    rdp_enabled: false
+    rdp_port: 3389
 ```
 
 ### `keys.yaml` — SSH Keys
@@ -263,7 +280,7 @@ Set `auth.mode: local` and `secure_mode: true`. Place your TLS cert at `~/.confi
 
 ### Multi-User
 
-Each user gets their own session collection. The first user is created via the bootstrap prompt on first login. Additional accounts can be created via the "+ Account" button in the top bar. Sign out and sign in as a different user to switch session collections.
+Each user gets their own session collection. The first user is created via the bootstrap prompt on first login and becomes an administrator. Administrators can manage additional accounts from the top bar; sign out and sign in as another user to switch session collections.
 
 ## Directory Layout
 
@@ -298,8 +315,13 @@ webmux/                          Source / install directory (WEBMUX_ROOT)
 | `GET` | `/api/health` | Health check |
 | `POST` | `/api/auth/bootstrap` | First-run account creation |
 | `POST` | `/api/auth/login` | Login (returns JWT) |
+| `POST` | `/api/auth/refresh` | Refresh an authenticated JWT |
+| `POST` | `/api/auth/ticket` | Create a short-lived WebSocket ticket |
 | `POST` | `/api/auth/register` | Create additional account (requires auth) |
 | `GET` | `/api/auth/status` | Auth mode + bootstrap status |
+| `GET` | `/api/auth/me` | Get the current account |
+| `GET` | `/api/auth/users` | List accounts (administrator only) |
+| `DELETE` | `/api/auth/users/:username` | Delete an account (administrator only) |
 | `GET` | `/api/sessions` | List sessions (scoped to current user) |
 | `POST` | `/api/sessions` | Create session |
 | `DELETE` | `/api/sessions/:id` | Delete session |
@@ -320,10 +342,14 @@ webmux/                          Source / install directory (WEBMUX_ROOT)
 | `GET` | `/api/agents/:agentId/sessions` | List sessions for one configured agent |
 | `POST` | `/api/agents/:agentId/attach` | Attach to a validated tmux session |
 | `POST` | `/api/agents/:agentId/scratch` | Open or reuse an agent scratch shell |
+| `GET` | `/api/vnc/sessions` | List VNC sessions |
+| `POST` | `/api/vnc/sessions` | Create a VNC session |
+| `GET` | `/api/rdp/sessions` | List RDP sessions |
+| `POST` | `/api/rdp/sessions` | Create an RDP session |
 
 ### WebSocket
 
-Connect to `/api/term/:sessionId?token=<jwt>` for terminal I/O.
+The browser obtains a short-lived WebSocket ticket and connects to `/api/term/:sessionId?ticket=<ticket>` for terminal I/O. Token query parameters remain a compatibility fallback. VNC and RDP use `/api/vnc/ws/:sessionId` and `/api/rdp/ws/:sessionId` respectively.
 
 | Type | Direction | Fields |
 |------|-----------|--------|
@@ -359,6 +385,12 @@ make lint
 ```
 
 If Playwright does not publish a bundled Chromium build for the host OS, set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` to a compatible installed Chrome or Chromium executable before running `npm run test:e2e`.
+
+## Contributing
+
+WebMux is maintained through [GitHub Issues](https://github.com/jordanhubbard/webmux/issues) and pull requests. Before opening a pull request, run `make test` and `make lint`; describe the user-visible change and link the issue it addresses.
+
+Thanks to the people who have contributed code and reviews as WebMux grew beyond its original one-person experiment, including [Isaiah Weiner](https://github.com/zoratu), [Shawn Edwards](https://github.com/lesserevil), and [Trent Nelson](https://github.com/tpn). GitHub's [contributors page](https://github.com/jordanhubbard/webmux/graphs/contributors) is the canonical, evolving record.
 
 ## Security Notes
 
@@ -399,7 +431,7 @@ On Linux, run `loginctl enable-linger $USER` to start the service at boot withou
 
 ### The continuing adventures of Jordan Hubbard and Sir Reginald von Fluffington III
 
-> *Part 5 of an ongoing chronicle.  [<-- Part 4: Aviation](https://github.com/jordanhubbard/Aviation#the-totally-true-and-not-at-all-embellished-history-of-aviation) | [Part 6: Rocky -->](https://github.com/jordanhubbard/rocky#the-totally-true-and-not-at-all-embellished-history-of-rocky)*
+> *Part 5 of an ongoing chronicle.  [<-- Part 4: Aviation](https://github.com/jordanhubbard/Aviation#the-totally-true-and-not-at-all-embellished-history-of-aviation) | [The story continues in mac -->](https://github.com/jordanhubbard/mac)*
 > *Sir Reginald von Fluffington III appears throughout.  He does not endorse any of it.*
 
 The programmer had, at various points, built a shell extension language, a Scheme interpreter, a programming language from scratch, and eight aviation applications in three languages.  What he had not done, until now, was stare at a wall of terminals and think, "This should be a website."
@@ -430,9 +462,9 @@ The security model was, by the programmer's standards, restrained.  Passwords he
 
 Sir Reginald had, by this point, migrated from the keyboard to the sectional chart that was still on the kitchen table from the Aviation project.  He was lying on the part that showed Class B airspace around SFO, which he considered his territory, and which was now covered in cat hair in a pattern that, if you squinted, resembled a denial-of-service attack on the programmer's ability to plan approaches.
 
-What the programmer did next is documented in [Part 6: Rocky](https://github.com/jordanhubbard/rocky#the-totally-true-and-not-at-all-embellished-history-of-rocky) -- specifically, what happens when the programmer deploys a persistent autonomous agent to a remote server in New Jersey and gives it a SOUL.md.
+What the programmer did next eventually became [mac](https://github.com/jordanhubbard/mac), a multi-agent coordinator control plane. The route from one wall of terminals to a fleet of durable agents was neither direct nor sensible, but it is documented there for anyone determined to follow it.
 
-As of this writing, WebMux has been used in production by exactly one person, who also wrote it.  Sir Reginald continues to withhold his endorsement across all six projects, citing "procedural concerns," "insufficient tuna," "a general atmosphere of hubris," "aviation," and, in a new filing delivered by walking across every open terminal session simultaneously in what can only be described as an analog implementation of broadcast mode, "multiplexing."
+WebMux did not remain a one-person production experiment. Other humans now contribute code, reviews, bug reports, and operating experience. Sir Reginald continues to withhold his endorsement, citing "procedural concerns," "insufficient tuna," "a general atmosphere of hubris," "aviation," and, in a filing delivered by walking across every open terminal session simultaneously in what can only be described as an analog implementation of broadcast mode, "multiplexing."
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,28 +2,26 @@
 
 ## Overview
 
-WebMux is a web-native terminal multiplexer built as a two-tier application: a React frontend and a Node.js backend, communicating over REST and WebSocket.
+WebMux is a browser-based remote workspace built as a React frontend and Node.js backend. REST manages configuration and session lifecycle; WebSockets carry interactive terminal, VNC, and RDP traffic.
 
 ## Component Diagram
 
 ```
-Browser                          Jump Box (WebMux Server)
-┌──────────────────────┐        ┌─────────────────────────────────────┐
-│  React + xterm.js    │  HTTP  │  Express                            │
-│  ┌────────────────┐  │◄──────►│  ├── REST API (sessions, hosts,     │
-│  │ Workspace      │  │        │  │   config, auth)                   │
-│  │ ├── Tile       │  │  WS    │  ├── WebSocket handler              │
-│  │ │   └ Terminal  │  │◄──────►│  │   └── PresenceService            │
-│  │ ├── Tile       │  │        │  ├── SessionBroker                   │
-│  │ └── ...        │  │        │  │   └── TransportLauncher           │
-│  ├────────────────┤  │        │  │       ├── SSH (via node-pty)      │
-│  │ TopBar         │  │        │  │       └── Mosh (via node-pty)     │
-│  │ ConnectionDlg  │  │        │  ├── PersistenceManager (YAML)       │
-│  │ LoginPage      │  │        │  └── CredentialHandler (in-memory)   │
-│  └────────────────┘  │        └─────────────────────────────────────┘
-└──────────────────────┘                    │
-                                           ▼
-                                    Remote Hosts (SSH/Mosh)
+Browser                                WebMux Host
+┌──────────────────────────┐           ┌──────────────────────────────────┐
+│ React application        │   HTTP    │ Express REST API                 │
+│ ├ Terminal workspace     │◄─────────►│ ├ auth, users, config, hosts    │
+│ │ └ xterm.js tiles       │           │ └ terminal/VNC/RDP/agent state │
+│ ├ Desktop workspace      │ WebSocket │                                  │
+│ │ ├ VNC client           │◄─────────►│ Session brokers and proxies      │
+│ │ └ Guacamole RDP client │           │ ├ node-pty: SSH, mosh, exec     │
+│ ├ Agent workspace        │           │ ├ VNC WebSocket proxy           │
+│ └ Navigation and dialogs │           │ └ guacd RDP proxy               │
+└──────────────────────────┘           │                                  │
+                                       │ YAML/JSONL persistence           │
+                                       └───────────────┬──────────────────┘
+                                                       ▼
+                                         Remote hosts and tmux sessions
 ```
 
 ## Backend Services
@@ -31,18 +29,22 @@ Browser                          Jump Box (WebMux Server)
 | Service | Responsibility |
 |---------|---------------|
 | **SessionBroker** | Session lifecycle (create, reconnect, delete, resize), layout positioning |
+| **VncBroker / RdpBroker** | Desktop session lifecycle, ownership, layout, and reconnect state |
 | **TransportLauncher** | Spawns SSH/mosh processes via node-pty, manages PTY handles |
 | **PresenceService** | Multi-viewer tracking, focus management, WebSocket broadcast |
 | **CredentialHandler** | In-memory password storage with 5-minute TTL, auto-zeroing |
-| **PersistenceManager** | YAML config I/O, atomic writes, JSONL audit logging, file watchers |
+| **AgentService** | Discovers configured tmux sessions and creates validated attach or scratch sessions |
+| **PersistenceManager** | Runtime config/state I/O, atomic writes, JSONL audit logging, file watchers |
 
 ## Frontend Components
 
 | Component | Responsibility |
 |-----------|---------------|
-| **App** | Auth routing, config loading, top-level state |
-| **TopBar** | Navigation, font/terminal size controls, broadcast toggle, auth badge |
-| **Workspace** | 2D tile grid, session CRUD, split positioning |
+| **App** | Auth lifecycle, workspace routing, config loading, top-level state |
+| **TopBar** | Workspace navigation, terminal controls, auth countdown, account administration |
+| **Workspace** | Terminal grid, session CRUD, movement, minimization, themes, lock, and auto-scroll |
+| **GraphicsWorkspace** | Shared grid and fullscreen flows for VNC and RDP sessions |
+| **AgentWorkspace** | Lists agent tmux sessions and hosts attach and scratch terminals |
 | **Tile** | Terminal chrome (title, status, controls), border/focus styling |
 | **Terminal** | xterm.js instance, WebSocket connection, resize handling |
 | **ConnectionDialog** | Host selection, auth method, transport choice |
@@ -56,8 +58,10 @@ Browser                          Jump Box (WebMux Server)
 3. Frontend opens WebSocket to `/api/term/:id`
 4. PresenceService tracks viewer, assigns focus
 5. Terminal data flows: PTY stdout -> WebSocket -> xterm.js (and reverse for input)
-6. Session state persisted to YAML after each change
+6. Session metadata and layout are persisted under `WEBMUX_HOME`; audit events are appended as JSONL
+
+Desktop sessions follow the same REST-managed lifecycle, but their interactive streams use protocol-specific WebSocket handlers. VNC traffic is proxied directly; RDP traffic is translated through `guacd`. Agent sessions are internal terminal sessions created only after the requested tmux target passes access and existence checks.
 
 ## Configuration
 
-All config is YAML in `webmux/config/`. See the main README for format details.
+Runtime configuration is YAML under `WEBMUX_HOME/config/`, which defaults to `~/.config/webmux/config/`. Files in `webmux/config.defaults/` are templates copied on first run, not live configuration. See the main README for formats and deployment details.

--- a/webmux/README.md
+++ b/webmux/README.md
@@ -1,293 +1,35 @@
-# WebMux
+# WebMux Application Workspace
 
-A web-native tmux-on-a-jump-box: a persistent shared terminal wall that runs in your browser.
+This directory contains the WebMux application workspaces:
 
-## Features
+- `backend/`: Express, WebSocket, and `node-pty` services
+- `frontend/`: React, Vite, xterm.js, VNC, and RDP clients
+- `config.defaults/`: templates copied to `WEBMUX_HOME` on first run
+- `examples/`: optional configuration examples
+- `scripts/`: application build and runtime helpers
+- `service/`: Windows service support and macOS/Linux service templates
 
-- **2D tiled terminal workspace** — scrollable grid of live SSH sessions
-- **xterm.js** — full terminal emulation in the browser (256-colour, ligatures, clipboard)
-- **node-pty** — proper PTY semantics on the jump box
-- **Persistent sessions** — sessions survive browser tab closes; reconnect from any tab
-- **Multi-viewer** — multiple browser tabs can watch the same session; one has keyboard focus at a time
-- **Split right / split below** — tile your workspace like a tiling window manager
-- **Keyboard terminal cycling** — `Ctrl+Shift+<` and `Ctrl+Shift+>` focus previous/next terminal tiles
-- **Global font size** — resize all terminals at once
-- **Two auth modes**:
-  - **Secure mode** — local login + HTTPS, Argon2id password hashing
-  - **Trusted mode** — no auth, HTTP only, for protected internal networks
-- **YAML configuration** — human-editable, lift-and-shift deployment
-- **SSH with keepalive** — `ServerAliveInterval`, `ServerAliveCountMax`, `ConnectTimeout`
-- **Audit log** — JSONL append-only event log
-- **Optional agent views** — disabled-by-default tmux-backed agent session browser
-
-## Quick Start
-
-### Prerequisites
-
-- Node.js ≥ 20
-- `ssh` available on the jump box (`ssh.exe` on `PATH` when running on Windows)
-- (Optional) `sshpass` for password-based SSH auth
-- (Optional) `mosh` on both ends for mosh transport
-
-### Install & Build
-
-```bash
-cd webmux
-npm install
-npm run build
-```
-
-### Configure
-
-Edit `config/app.yaml`:
-
-```yaml
-app:
-  listen_host: 0.0.0.0
-  http_port: 8080
-  secure_mode: false        # true = require login + HTTPS
-  trusted_http_allowed: true
-  default_term:
-    cols: 80
-    rows: 24
-    font_size: 14
-    font_family: ui-monospace, "SFMono-Regular", Monaco, Menlo, Consolas, "Liberation Mono", "DejaVu Sans Mono", monospace
-  font_faces:
-    # - family: Custom Mono
-    #   source: fonts/CustomMono.woff2
-    #   weight: 400
-    #   style: normal
-  terminal_grid:
-    max_cols: null      # null, 0, or omitted = unlimited
-    max_rows: null      # null, 0, or omitted = unlimited
-```
-
-`WEBMUX_TERMINAL_GRID_MAX_COLS` and `WEBMUX_TERMINAL_GRID_MAX_ROWS` can override those YAML values at runtime.
-
-`default_term.font_family` accepts a normal comma-separated CSS font-family list. Multi-word family names such as `Custom Mono` are normalized to quoted CSS family names, so `Custom Mono, Monaco, monospace` is returned and saved as `"Custom Mono", Monaco, monospace`.
-
-Optional `app.font_faces` entries let WebMux host local font files for browser clients. `source` paths must be relative paths to `.otf`, `.ttf`, `.woff`, or `.woff2` files; they are resolved relative to the real `app.yaml` path, so symlinked config files can keep fonts beside the shared config. The frontend fetches configured font files through authenticated same-origin routes and registers them before refitting terminals. Once a face is declared, reference its `family` name from `default_term.font_family`.
-
-Agent views are configured under `app.agents` and are disabled by default. See `../docs/agent-views.md` and `examples/agent-views/app.yaml` for setup, security notes, optional status hooks, and host-switcher examples.
-
-Add hosts to `config/hosts.yaml`:
-
-```yaml
-hosts:
-  - id: build01
-    hostname: build01.example.com
-    port: 22
-    tags: [linux, build]
-    mosh_allowed: false
-```
-
-### Run
-
-```bash
-npm start
-```
-
-Open `http://localhost:8080` in your browser.
-
-On first run with `auth.mode: local`, you will be prompted to create an admin account.
-
-### Windows
-
-Native Windows hosting requires a current Windows release with ConPTY, Node.js 20 or newer, and Microsoft OpenSSH Client. The service installer also uses .NET Framework 4.6.1 or newer, which is included with supported Windows releases. From an elevated PowerShell prompt, missing prerequisites can be installed with:
-
-```powershell
-winget install OpenJS.NodeJS.LTS
-winget install Git.Git
-Add-WindowsCapability -Online -Name OpenSSH.Client~~~~0.0.1.0
-```
-
-Open a new PowerShell window, verify `ssh -V`, then install and start WebMux:
-
-```powershell
-git clone https://github.com/jordanhubbard/webmux.git
-cd webmux\webmux
-npm ci
-npm run build
-npm start
-```
-
-Runtime data defaults to `%USERPROFILE%\.config\webmux`. `ssh.exe` must remain on `PATH`; WebMux resolves it to an absolute path before launching ConPTY. Key-based SSH is recommended because native Windows does not normally provide `sshpass`. Mosh and tmux-backed agent views require their respective executables and remain optional; agent views are intended for macOS/Linux hosts.
-
-For automatic startup through Windows Service Control Manager, keep the elevated PowerShell window open and run:
-
-```powershell
-npm run service:install
-npm run service:status
-```
-
-The installer prompts for the current account's password so the service retains access to that user's runtime configuration, SSH keys, and known-hosts data. It downloads and checksum-verifies the stable WinSW 2.12.0 wrapper, enables automatic delayed startup and failure recovery, and starts the service. Manage it with `npm run service:start`, `service:stop`, `service:restart`, and `service:uninstall`; uninstalling preserves data and logs. The one-time wrapper download requires access to GitHub.
-
-`npm run service:install -- -LocalSystem` is available for isolated installations that do not need user SSH credentials. The repository-level `make install` target continues to support launchd and systemd only. See the root README's **Hosting on Windows** section for firewall, environment-variable, service-account, and native build fallback instructions.
-
-## Directory Layout
-
-```
-webmux/
-  config/
-    app.yaml          # Application settings
-    auth.yaml         # Auth mode + hashed password
-    hosts.yaml        # Known SSH hosts
-    layout.yaml       # Tile positions
-    keys.yaml         # Saved key references
-    tls/
-      cert.pem        # TLS certificate (generate separately)
-      key.pem         # TLS private key
-  data/
-    sessions/         # Persisted session metadata
-    events/           # JSONL audit log
-    cache/
-  logs/
-  backend/            # Node.js/TypeScript backend
-  frontend/           # React/TypeScript frontend
-  web/                # Built frontend (served by backend)
-```
-
-Everything lives under one root. Copy the directory to another machine, run `npm install && npm run build`, and start the service.
-
-## Authentication Modes
-
-### Trusted Mode (no auth)
-
-```yaml
-# config/auth.yaml
-auth:
-  mode: none
-```
-
-```yaml
-# config/app.yaml
-app:
-  secure_mode: false
-  trusted_http_allowed: true
-```
-
-Only use on a network you fully control. The UI displays a "⚠ Trusted" badge.
-
-### Secure Mode (local auth + HTTPS)
-
-```yaml
-# config/auth.yaml
-auth:
-  mode: local
-  bootstrap_required: true   # becomes false after first login
-```
-
-```yaml
-# config/app.yaml
-app:
-  secure_mode: true
-  https_port: 8443
-```
-
-Place your TLS certificate at `config/tls/cert.pem` and `config/tls/key.pem`.
-
-Passwords are stored as Argon2id hashes. Plain-text passwords are never written to disk.
-
-## API Reference
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/health` | Health check |
-| `POST` | `/api/auth/login` | Login (returns JWT) |
-| `POST` | `/api/auth/bootstrap` | First-run account creation |
-| `GET` | `/api/auth/status` | Auth mode + bootstrap status |
-| `GET` | `/api/sessions` | List sessions |
-| `POST` | `/api/sessions` | Create session |
-| `DELETE` | `/api/sessions/:id` | Delete session |
-| `POST` | `/api/sessions/:id/reconnect` | Reconnect session |
-| `GET` | `/api/hosts` | List saved hosts |
-| `POST` | `/api/hosts` | Add host |
-| `PUT` | `/api/hosts/:id` | Update host |
-| `DELETE` | `/api/hosts/:id` | Delete host |
-| `GET` | `/api/config` | Get app config |
-| `PUT` | `/api/config` | Update app config |
-| `GET` | `/api/config/layout` | Get layout |
-| `PUT` | `/api/config/layout` | Update layout |
-| `GET` | `/api/agents/config` | Get normalized agent-view config |
-| `GET` | `/api/agents/sessions` | List configured agent tmux sessions |
-| `POST` | `/api/agents/:agentId/attach` | Attach to a validated tmux session |
-| `POST` | `/api/agents/:agentId/scratch` | Open or reuse an agent scratch shell |
-| `WS` | `/api/term/:id?token=<jwt>` | Terminal WebSocket |
-
-### WebSocket Message Types
-
-| Type | Direction | Fields |
-|------|-----------|--------|
-| `input` | client→server | `data` (string) |
-| `resize` | client→server | `cols`, `rows` |
-| `focus` | client→server | — |
-| `output` | server→client | `data` (string) |
-| `status` | server→client | `state`, `message` |
-| `viewer_join` | server→client | `viewer_id`, `viewer_count`, `focus_owner` |
-| `viewer_leave` | server→client | `viewer_id`, `viewer_count`, `focus_owner` |
-| `focus` | server→client | `focus_owner`, `viewer_count` |
+The repository-level [README](../README.md) is the canonical guide for features, configuration, security, installation, and deployment. Agent workspace setup is documented in [Agent Views](../docs/agent-views.md).
 
 ## Development
 
+From this directory:
+
 ```bash
-# Run backend in watch mode
-npm run dev:backend
-
-# Run frontend dev server (proxies /api to localhost:8080)
-npm run dev:frontend
-
-# Run tests
+npm install
+npm run build
+npm run typecheck
 npm test
-
-# Run browser tests (install Chromium first if needed)
-npx playwright install chromium
-npm run test:e2e
-
-# Lint
 npm run lint
 ```
 
-If Playwright does not publish a bundled Chromium build for the host OS, point the tests at a compatible installed Chrome or Chromium executable. For example:
+Run the development servers separately when working on the UI and API:
 
 ```bash
-PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/usr/bin/google-chrome npm run test:e2e
+npm run dev:backend
+npm run dev:frontend
 ```
 
-## Security Notes
+The frontend development server proxies API requests to the backend. For browser tests, install Playwright Chromium with `npx playwright install chromium`, then run `npm run test:e2e`. Set `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` when using an existing compatible Chrome or Chromium installation.
 
-- Remote **passwords** are never written to disk. They are held in memory only for the duration of session setup (TTL: 5 minutes), then zeroed and discarded.
-- **Remote usernames** entered for password-based logins are not persisted.
-- **JWT tokens** are signed with `JWT_SECRET` (set via environment variable in production).
-- In secure mode, use HTTPS and set `JWT_SECRET` to a strong random value.
-- Rate limiting is applied globally (300 req/min) and to the auth endpoints (10 req/15 min).
-
-## Deployment
-
-### Environment Variables
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `WEBMUX_ROOT` | `../..` relative to `backend/dist` | Root directory |
-| `WEBMUX_HOME` | `~/.config/webmux` | Runtime data (`%USERPROFILE%\.config\webmux` on Windows) |
-| `HTTP_PORT` | from `app.yaml` | Override HTTP port |
-| `HTTPS_PORT` | from `app.yaml` | Override HTTPS port |
-| `JWT_SECRET` | `webmux-dev-secret-change-in-production` | **Change in production** |
-
-### systemd
-
-```ini
-[Unit]
-Description=WebMux Terminal Wall
-After=network.target
-
-[Service]
-Type=simple
-WorkingDirectory=/opt/webmux
-Environment=WEBMUX_ROOT=/opt/webmux
-Environment=JWT_SECRET=<your-secret>
-ExecStart=/usr/bin/node backend/dist/index.js
-Restart=on-failure
-
-[Install]
-WantedBy=multi-user.target
-```
+Runtime files do not belong in this directory. WebMux reads configuration and stores state under `~/.config/webmux/` by default; set `WEBMUX_HOME` to use another location.


### PR DESCRIPTION
## Summary
- update the root guide for desktop, agent, navigation, session-expiry, and current API features
- make the root README canonical and reduce the inner README to workspace-specific development guidance
- split macOS, Linux, and Windows prerequisites, bring-up, services, and limitations into focused platform guides
- refresh architecture and runtime configuration documentation
- clarify that public work enters through GitHub Issues and pull requests, while maintainers use mac for task tracking and dispatch; beads is not used
- credit confirmed human contributors while excluding fictional identities and bots
- replace the obsolete Rocky continuation with https://github.com/jordanhubbard/mac

## Validation
- `make test-unit` (395 tests)
- `npm run lint` (0 errors, 11 pre-existing warnings)
- `git diff --check`

Closes #32